### PR TITLE
Nativize submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,0 @@
-[submodule "fun/ext/pitools"]
-	path = fun/ext/pitools
-	url = http://github.com/pabloi/pi-tools
-[submodule "fun/ext/markerDataCleaning"]
-	path = fun/ext/markerDataCleaning
-	url = https://github.com/pabloi/markerDataCleaning

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,14 @@ recomputed parameters are silently discarded:
 | `plotting/` | Visualization utilities |
 | `eventReview/` | Event validation helpers |
 | `+dataMotion/`, `+Hreflex/`, `+utils/` | Namespace packages |
+| `ext/` | Vendored third-party libraries (BTK, pitools, markerDataCleaning) |
+
+**Vendored code in `fun/ext/`:** Files under `fun/ext/pitools/` and
+`fun/ext/markerDataCleaning/` are vendored copies of upstream
+libraries — do not reformat or apply labTools code style to them. To
+update a vendored dependency, copy only the used function files from
+the upstream repository (commit hashes in ATTRIBUTION files); do not
+wholesale copy the entire repo.
 
 ### Key Functions
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,14 +108,16 @@ recomputed parameters are silently discarded:
 | `plotting/` | Visualization utilities |
 | `eventReview/` | Event validation helpers |
 | `+dataMotion/`, `+Hreflex/`, `+utils/` | Namespace packages |
-| `ext/` | Vendored third-party libraries (BTK, pitools, markerDataCleaning) |
+| `ext/` | External libraries: BTK (unmodified), pitools and markerDataCleaning (maintained as part of labTools) |
 
-**Vendored code in `fun/ext/`:** Files under `fun/ext/pitools/` and
-`fun/ext/markerDataCleaning/` are vendored copies of upstream
-libraries — do not reformat or apply labTools code style to them. To
-update a vendored dependency, copy only the used function files from
-the upstream repository (commit hashes in ATTRIBUTION files); do not
-wholesale copy the entire repo.
+**Code in `fun/ext/pitools/` and `fun/ext/markerDataCleaning/`:** These
+are signal processing and marker analysis functions originally from the
+pi-tools and markerDataCleaning repositories, both authored by members
+of the SML Laboratory. They are maintained as part of labTools and
+should be updated and reformatted to conform to labTools code style as
+needed. The ATTRIBUTION files record the original upstream commit hashes
+for provenance. Unlike `fun/ext/BTK/`, these files are not expected to
+track an external upstream — treat them as first-party labTools code.
 
 ### Key Functions
 

--- a/README.md
+++ b/README.md
@@ -15,13 +15,14 @@ through stride-indexed adaptation metrics and group statistics.
 
 1. [Requirements](#requirements)
 2. [Getting Started](#getting-started)
-3. [Repository Layout](#repository-layout)
-4. [Data Pipeline Overview](#data-pipeline-overview)
-5. [Key Classes](#key-classes)
-6. [Working with Your Data](#working-with-your-data)
-7. [Example Scripts](#example-scripts)
-8. [Generating Documentation](#generating-documentation)
-9. [Reporting Bugs](#reporting-bugs)
+3. [Third-Party Libraries](#third-party-libraries)
+4. [Repository Layout](#repository-layout)
+5. [Data Pipeline Overview](#data-pipeline-overview)
+6. [Key Classes](#key-classes)
+7. [Working with Your Data](#working-with-your-data)
+8. [Example Scripts](#example-scripts)
+9. [Generating Documentation](#generating-documentation)
+10. [Reporting Bugs](#reporting-bugs)
 
 ---
 
@@ -64,6 +65,28 @@ through stride-indexed adaptation metrics and group statistics.
 
 ---
 
+## Third-Party Libraries
+
+labTools vendors several open-source libraries directly in `fun/ext/`.
+No submodule initialization is needed — a plain `git clone` is
+sufficient to get a fully functional copy of the repository.
+
+| Library | Path | License | Purpose |
+|---|---|---|---|
+| [BTK][btk] | `fun/ext/BTK/` | LGPLv3 | C3D file I/O |
+| [pi-tools][pitools] | `fun/ext/pitools/` | GPL v2 | Signal processing, utilities |
+| [markerDataCleaning][mdc] | `fun/ext/markerDataCleaning/` | See ATTRIBUTION | Marker outlier detection |
+
+Only the subset of pi-tools and markerDataCleaning functions referenced
+by the labTools pipeline has been vendored. See
+`fun/ext/pitools/LICENSE` and
+`fun/ext/markerDataCleaning/ATTRIBUTION.md` for attribution details.
+
+[pitools]: https://github.com/pabloi/pi-tools
+[mdc]: https://github.com/pabloi/markerDataCleaning
+
+---
+
 ## Repository Layout
 
 ```
@@ -89,7 +112,8 @@ labTools/
 │   ├── eventReview/           % Event validation helpers
 │   ├── +dataMotion/           % Namespace: marker/segment utilities
 │   ├── +Hreflex/              % Namespace: H-reflex analysis
-│   └── +utils/                % Namespace: general utilities
+│   ├── +utils/                % Namespace: general utilities
+│   └── ext/                   % Vendored third-party libraries (BTK, pitools, etc.)
 ├── gui/
 │   ├── importc3d/             % c3d2mat and GetInfoGUI (primary entry point)
 │   ├── createStudy/           % uiCreateStudy — experiment setup

--- a/README.md
+++ b/README.md
@@ -65,11 +65,11 @@ through stride-indexed adaptation metrics and group statistics.
 
 ---
 
-## Third-Party Libraries
+## External Libraries
 
-labTools vendors several open-source libraries directly in `fun/ext/`.
-No submodule initialization is needed — a plain `git clone` is
-sufficient to get a fully functional copy of the repository.
+labTools includes several external libraries in `fun/ext/`. No submodule
+initialization is needed — a plain `git clone` is sufficient to get a
+fully functional copy of the repository.
 
 | Library | Path | License | Purpose |
 |---|---|---|---|
@@ -77,10 +77,12 @@ sufficient to get a fully functional copy of the repository.
 | [pi-tools][pitools] | `fun/ext/pitools/` | GPL v2 | Signal processing, utilities |
 | [markerDataCleaning][mdc] | `fun/ext/markerDataCleaning/` | See ATTRIBUTION | Marker outlier detection |
 
-Only the subset of pi-tools and markerDataCleaning functions referenced
-by the labTools pipeline has been vendored. See
-`fun/ext/pitools/LICENSE` and
-`fun/ext/markerDataCleaning/ATTRIBUTION.md` for attribution details.
+BTK is included unmodified. The pi-tools and markerDataCleaning
+functions were originally authored by members of the SML Laboratory and
+are maintained as part of labTools; they may diverge from the original
+repositories over time. The ATTRIBUTION files record the upstream commit
+hashes at the time of initial incorporation. See
+`fun/ext/pitools/LICENSE` for the pi-tools GPL v2 license.
 
 [pitools]: https://github.com/pabloi/pi-tools
 [mdc]: https://github.com/pabloi/markerDataCleaning

--- a/fun/ext/markerDataCleaning/ATTRIBUTION.md
+++ b/fun/ext/markerDataCleaning/ATTRIBUTION.md
@@ -1,0 +1,12 @@
+# markerDataCleaning Attribution
+
+Source: https://github.com/pabloi/markerDataCleaning
+Author: pabloi (Pablo Iturralde)
+No license file is present in the source repository.
+Commit vendored: eadf10cc99d2417c2b02546b26fd687415d6926d
+
+Only the functions referenced by the labTools processing pipeline have
+been vendored. The files have not been modified from the original. The
+full source repository contains additional functions for position
+reconstruction, model variants, and testing utilities that are not
+included here.

--- a/fun/ext/markerDataCleaning/fun/computeDiffMatrix.m
+++ b/fun/ext/markerDataCleaning/fun/computeDiffMatrix.m
@@ -1,0 +1,7 @@
+function [D] = computeDiffMatrix(pos)
+%Gets position data as N markers x 3D x M frames and for each frame
+%computes all pairwise differences btw marker components, returns Nx3xNxM
+[N,dim,M]=size(pos);
+D=bsxfun(@minus,reshape(pos,[N,dim,1,M]),reshape(permute(pos,[2,1,3]),[1,dim,N,M]));
+end
+

--- a/fun/ext/markerDataCleaning/fun/computeDistanceMatrix.m
+++ b/fun/ext/markerDataCleaning/fun/computeDistanceMatrix.m
@@ -1,0 +1,8 @@
+function [D] = computeDistanceMatrix(pos)
+%Gets position data as N markers x 3D x M frames and for each frame
+%computes all pairwise distances btw markers, returns NxNxM
+
+[E] = computeDiffMatrix(pos);
+D=sqrt(squeeze(sum(E.^2,2)));
+end
+

--- a/fun/ext/markerDataCleaning/models/markerModel.m
+++ b/fun/ext/markerDataCleaning/models/markerModel.m
@@ -1,0 +1,455 @@
+classdef markerModel
+    
+    properties
+        markerLabels %Mx1 cell array
+        trainingData %Mx3xN
+        statMean
+        statStd
+        trainingLogLPrctiles=[]; %Stores prctiles for log-l distribution in training data
+        statPrctiles
+        activeStats
+    end
+    properties(Dependent)
+        Nmarkers
+        statMedian
+    end
+    
+    methods
+        function mm=markerModel(trainData,labels)
+            mm.markerLabels=labels;
+            mm.trainingData=trainData;
+            trainStats=mm.summaryStats(trainData);
+            mm.statMean=nanmean(trainStats,2);
+            mm.statStd=nanstd(trainStats,[],2);
+            mm.statPrctiles=prctile(trainStats,0:100,2);
+            mm.trainingLogLPrctiles=prctile(mm.loglikelihood(trainData),0:100,2);
+            mm.activeStats=true(size(mm.statMean));
+        end
+        function M = get.Nmarkers(this)
+            M=size(this.trainingData,1);
+        end
+        function mu = get.statMedian(this)
+            mu=this.statPrctiles(:,51);
+        end
+
+        %To be implemented in subclass:
+        [logL,g] = loglikelihood(this,data) %Returns PxN likelihood and gradient
+        i = indicatrix(this)
+        mapData = reconstruct(this,dataPrior,priorConfidence)
+        function [badFlag,outlierClass1,outlierClass2] = validateMarkerModel(this,verbose)
+            if nargin<2 || isempty(verbose)
+                verbose=true;
+            end
+            SS=this.stat2Matrix(this.statStd); %Get stds as matrix indexed by markers
+            %First: get reference data
+            [refModel,meanLB,meanUB,stdLB,stdUB,A,b]=getRefData();
+            %Second: drop non-shared markers from both reference and
+            %current model (that is the only thing that can be compared)
+            sharedMarkerList=this.getSharedMarkerList(refModel);
+            [this,keptIdx]=this.dropMarkers(sharedMarkerList,true);
+            [refModel,keptIdxRef,keptStats]=refModel.dropMarkers(sharedMarkerList,true);
+            %Third: check mean upper and lower bounds are satisfied
+            outlierClass2=this.statMean > meanUB(keptStats) | this.statMean< meanLB(keptStats);
+            %Fourth: check std upper and lower bounds are satisfied
+            outlierClassS=this.statStd > stdUB(keptStats) | this.statStd< stdLB(keptStats);
+            %Fifth: check inequality constraints
+            outlierClass1= A(:,keptStats)*this.statMean > b;
+            %Sixth: check, for the full given model, that each marker has
+            %some (2 or more) tight constraints, otherwise that marker is
+            %not being modeled properly
+            badFlag=any(outlierClass1 | outlierClass2 | outlierClassS);
+            sortedSTD=sort(SS); %Ascending order, along columns
+            badFlag=badFlag | any(sortedSTD(2,:)>15); %Marking as bad if second tightest std of constraints of any marker are above 15mm
+        end
+        function newThis = fixLabels(this)
+        %This function tries to permute labels in a model so the model
+        %would pass, or at least do better, at validate()
+        end
+
+        %Convenience functions:
+        function s = getRobustStd(this,CI)
+           %Uses the central confidence interval CI to estimate the std of the distribution
+           %assuming the central part is normally distributed 
+           %CI has to be a number in [0.02,.98]
+           if nargin<2
+               CI=.95;
+           elseif CI>.98 || CI<0.02
+               error('CI has to be a number in [0.02,.98]')
+           end
+           lb=50-100*CI/2; %Here I am assuming central CI
+           ub=100*CI/2 +50;
+           %Get the lb percentile:
+           w=1-(lb-floor(lb));
+           pl=this.statPrctiles(:,floor(lb)+[0,1]+1)*[w;1-w];
+           %Get the ub percentile:
+           w=1-(ub-floor(ub));
+           pu=this.statPrctiles(:,floor(ub)+[0,1]+1)*[w;1-w];
+           
+           %Get how many sigmas correspond to each of the chosen
+           %percentiles in a normal distribution:
+           Nsigma=2*erfinv(CI)*sqrt(2); %For the classical 0.95 value, this is 2*1.96 sigma, asumming central CI again
+           s=(pu-pl)/Nsigma;
+        end
+        function [fh]=seeModel(this)
+            data=this.trainingData;
+                fh=figure; 
+                c=colormap;
+                c(1,:)=[1 1 1];
+                colormap(c)
+                subplot(3,2,1)
+                plot(this.statPrctiles',0:100)
+                title('Training stat cdfs')
+                subplot(3,2,[2,4,6])
+                idx=all(all(~isnan(this.trainingData)));
+                d=this.trainingData(:,:,idx);
+                m=median(d,3); %This needs to be rotated accordingly on a frame-by-frame basis for the plot to work well
+                plot3(m(:,1),m(:,2),m(:,3),'o','LineWidth',2,'MarkerSize',4)
+                view(3)
+                axis equal
+                hold on
+                text(m(:,1),m(:,2),m(:,3),this.markerLabels)
+
+                
+                subplot(3,4,5)
+                s=this.stat2Matrix(this.statStd);
+                [s,xl,yl]=this.stat2Matrix(this.getRobustStd(.95));
+                if strcmp(xl,'markerLabels')
+                    xl=this.markerLabels;
+                end
+                if strcmp(yl,'markerLabels')
+                    yl=this.markerLabels;
+                end
+                s(s==0)=-5;
+                imagesc(s)
+                colorbar
+                caxis([-5 100])
+                title('\sigma training (mm)')
+                axis equal
+                axis tight
+                set(gca,'XTickLabels',xl,'XTickLabelRotation',90,'XTick',1:size(data,1),'YTickLabels',yl,'YTick',1:size(data,1))
+                subplot(3,4,6)
+                m=this.stat2Matrix(this.statMedian);
+                m(m==0)=NaN;
+                imagesc(m)
+                colorbar
+                caxis([nanmin(m(:))-100 nanmax(m(:))])
+                title('\mu training (mm)')
+                axis equal
+                axis tight
+                set(gca,'XTickLabels',xl,'XTickLabelRotation',90,'XTick',1:size(data,1),'YTickLabels',yl,'YTick',1:size(data,1))
+                
+%                 %Reference data
+%                 [m,s,l]=naiveDistances.getRefData();
+%                 subplot(3,4,9)
+%                 s=triu(s);
+%                 s(s==0)=-5;
+%                 m=triu(m);
+%                 m(m==0)=-25;
+%                 imagesc(s)
+%                 colorbar
+%                 %colormap(c)
+%                 caxis([-5 100])
+%                 title('\sigma reference (mm)')
+%                 axis equal
+%                 axis tight
+%                 set(gca,'XTickLabels',l,'XTickLabelRotation',90,'XTick',1:size(s,1),'YTickLabels',l,'YTick',1:size(s,1))
+%                 subplot(3,4,10)
+%                 imagesc(m)
+%                 caxis([-25 1000])
+%                 colorbar
+%                 title('\mu reference (mm)')
+%                 axis equal
+%                 axis tight
+%                 set(gca,'XTickLabels',l,'XTickLabelRotation',90,'XTick',1:size(s,1),'YTickLabels',l,'YTick',1:size(s,1))
+        end
+        function [newThis,keptIdx,keptStats]=dropMarkers(this,markerList,keepMarkersFlag)
+            %Drops the markers in markerList from the model, if present.
+            %If keepMarkersFlag is set, then we only keep the markers in
+            %markerList and drop the rest. The markers are re-ordered to
+            %match the order in the given list.
+            %keptIdx is such that this.markerLabels(keptIdx)=newThis.markerLabels
+            %And will be equal to markerList if ALL markers in markerList are present
+            %keptStats is such that this.statMean(keptStats)=newThis.statMean
+            if nargin<3 || isempty(keepMarkersFlag)
+                keepMarkersFlag=false; 
+            end
+            error('Unimplemented')
+        end
+        function [outlierMarkers,markerScores,logL] = outlierDetect(this,data,threshold,fastFlag)
+            if nargin<3 || isempty(threshold)
+                threshold=-5;
+            end
+            if nargin<4 || isempty(fastFlag)
+                fastFlag=false;
+            end
+            markerScores=[];
+            logL=[];
+            %One option: find outlier stats and disentangle those
+            %logL=this.loglikelihood(data);
+            %outStats=logL<(-threshold^2/2);
+            %[outlierMarkers]=markerModel.untangleOutliers(outStats,this.indicatrix);     
+            %Another: disentangle likelihoods themselves & then detect
+            markerScores = scoreMarkers(this,data,fastFlag);
+            outlierMarkers=markerScores<(-threshold^2/2);
+        end
+        function markerScores = scoreMarkers(this,data,fastFlag)
+           if nargin<3 || isempty(fastFlag)
+                fastFlag=false;
+           end
+           markerScores=this.scoreMarkersRanked(data,2); %Fast scoring
+           %This fast scoring works well if only one outlier marker is
+           %present, or if two or more non-adjacent (ie. no strong distance
+           %constraints) markers are present. Otherwise problematic.
+            if ~fastFlag %Improve scoring for complex situations
+           i=indicatrix(this); %MxP
+           markerScores=this.scoreMarkersFast(data);
+           outMarkers=this.outlierDetectFast(data);
+           badFrames=sum(outMarkers)>1; %More than one bad marker per frame
+           L=this.loglikelihood(data(:,:,badFrames));
+           badMarkers=any(outMarkers(:,badFrames),2); %This may only be useful on not too long trials (otherwise every marker will possibly be a part of at least one bad frame, and all markers will get selected)
+           badMarkers=true(size(badMarkers));
+           in=i(badMarkers,:); %Indicatrix of bad markers only
+           activeConstraints=any(in,1);
+           [markerScores(badMarkers,badFrames)]=markerModel.untangleLikelihoods(L(activeConstraints,:),in(:,activeConstraints));
+            else
+
+            end
+        end
+        function [labels1,labels2] = labelData(this,dataFrames)
+            error('This function doesnt work yet.')
+            M2=size(dataFrames,1); %Markers in data frame
+            M1=this.Nmarkers; %Markers in model (need not be equal)
+            if M1~=M2
+                error('Option to have different number of markers is not yet implemented.')
+            end
+            Nframes=size(dataFrames,3);
+            if Nframes~=1
+                error('Multiple frames not-yet supported')
+            end
+            %Heuristic 2: (to initialize labeling)
+            i1=this.indicatrix;
+            i2=this.indicatrix(true,M2);
+            i2=i2(:,this.activeStats);
+            dataFrames(isnan(dataFrames))=0; %TODO: what is the smart way to handle this?
+            S=this.summaryStats(dataFrames);
+            S=S(this.activeStats,:);
+            mu=this.statMedian(this.activeStats);
+            sigma=this.getRobustStd(.94);
+            sigma=sigma(this.activeStats);
+            for i=1:Nframes
+                %Heuristic: get most likely pair, one at a time:
+                counter=0;
+                labels1=cell(M2,1);
+                map=nan(M2,1);
+                L=markerModel.normalLogL(S(:,i),mu',sigma'); %This assumes normal distributions
+                mL=min(L(:));
+                L((isnan(L)))=mL;
+                P=i1*(1./sqrt(-L))/i2;
+                P=L;
+                while counter<M2
+                    counter=counter+1;
+                    [ii,jj]=find(P==max(P(:)),1,'first')
+                    map(jj)=ii;
+                    %i1(ii,:)=0;
+                    %L(:,i2(jj,:)==1)=-1e6;
+                    P(ii,:)=-Inf;
+                    P(:,jj)=-Inf;
+                end
+                labels1=this.markerLabels(map);
+                    
+                %TODO:  I want to get the most likely map of M2 onto
+                %M1, this is a permutation of M2, (idx: M1x1) such that
+                %sum(diag(P(:,idx))) is maximized.
+                %TODO: Need to think about what happens if M2< M1 (if larger,
+                %we just dont assign some)
+            end
+            %Heuristic 1: assign random labels, then try pair-wise
+            %permutations and see if they improve likelihood of data.
+            %Keep permutations that do, and reset pairwise list to try
+            %End when all pairwise permutations have been tried and none
+            %improves reconstruction
+            %Perhaps repeat a couple times and select best of final results
+            randInit=randperm(M1);
+            for i=1:Nframes
+                [newFrame,permList]=this.tryPermutations(dataFrames(randInit,:,i));
+            end
+            labels2=this.markerLabels(randInit);
+            labels2=markerModel.applyPermutationList(labels2,permList);
+            
+        end
+        function sortedData=sortMarkerOrder(model,data,labels)
+            % Convenience function that re-sorts the rows of data, so that
+            % they match the order of the labels in this model.
+            error('Unimplemented')
+            %To do: compare lists of labels and model.markerLabels, find
+            %sorting, and sort the data. Use compareLists()
+        end
+        function sharedMarkerList=getSharedMarkerList(model1,model2)
+            error('Unimplemented')
+        end
+    end
+    methods(Hidden)
+        function markerScores = scoreMarkersRanked(this,data,N)
+            if nargin<3
+                N=2; %Using second-worse score
+            end
+           L=loglikelihood(this,data); %PxN
+           [P,Nn]=size(L);
+           i=indicatrix(this); %MxP
+           if N>1
+               markerScores=nan(size(i,1),size(L,2));
+               for j=1:size(i,1) %Each marker
+                   aux=sort(L(i(j,:)==1,:),1);
+                   NN=min(N,size(aux,1));
+                   markerScores(j,:)=aux(NN,:);
+               end
+            else
+                markerScores=squeeze(min(i.*reshape(L,1,P,Nn),[],2));
+           end
+        end
+        function [dataFrame,permutationList]=tryPermutations(model,dataFrame,listToPermute)
+            %Tries to permute labels on single dataFrame to maximize
+            %likelihood of data.
+            permutationList=zeros(0,2);
+            %Benchmark to compare:
+            L0=model.loglikelihood(dataFrame);
+            bad=L0<-5^2/2;
+            nBad=sum(model.indicatrix* bad >0);
+            %TODO: start with markers associated to bad distances, and then move to a larger set
+            if nargin<3 || isempty(listToPermute)
+                %Run for bad markers.
+                if nBad>0
+                    listToPermute=find(model.indicatrix* bad >0);
+                    [dataFrame,permutationList]=tryPermutations(model,dataFrame,listToPermute);
+                end
+                %Run for all markers.
+                [dataFrame,permutationList2]=tryPermutations(model,dataFrame,1:size(dataFrame,1));
+                permutationList=[permutationList;permutationList2];
+            else
+                while nBad>0 %If no log-L is too bad, do nothing, save time.
+                    %Permutations to consider:
+                    listOfPermutations=nchoosek(listToPermute,2); %Pairwise permutations
+                    N=size(listOfPermutations,1);
+                    count=0;
+                    while count<N
+                       count=count+1;
+                       newDataFrame=dataFrame;
+                       newDataFrame=markerModel.applyPermutationList(dataFrame,listOfPermutations(count,:));
+                       L=model.loglikelihood(newDataFrame);
+                       if sum(L)>sum(L0) %Found permutation that improves things
+                           break %Exiting inner while-loop
+                       end
+                    end
+                    if sum(L)<=sum(L0) %Checking if while exited without making any improvements
+                        return %Inner loop finished without progress
+                    else %Improvement was made!
+                        %Update benchmark:
+                        dataFrame=newDataFrame;
+                        L0=L;
+                        nBad=sum(L0<-5^2/2);
+                        permutationList(end+1,:)=listOfPermutations(count,:); %Adding permutation to list
+                    end
+                end
+            end
+        end
+    end
+    methods(Static)
+        %To be implemented in subclass:
+        model = learn(data,labels)
+        [ss,g] = summaryStats(data) %Returns PxN summary stats, and P x 3M x N gradient 
+        %gradient can be P x 3M if it is the same for all frames, as is the case in linear models       
+        [M,xl,yl]=stat2Matrix(stats)
+        [model,meanLB,meanUB,stdLB,stdUB,A,b]=getRefData(); %Returns an example, well-calibrated model
+        
+        %Convenience functions:
+        function lL=normalLogL(values,means,stds)
+            %values is PxN, means and stds are Px1
+            %Returns PxN likelihood of value under each normal
+            d=.5*((values-means)./stds).^2;
+            lL=-d;% -log(stds) -.9189;
+            %lL=-sqrt(2*d); %Mahalanobis distance
+            %.9189 = log(2*pi)/2
+        end
+        function frameScores=marker2frameScoresNaive(markerScores)
+            frameScores=nanmean(markerScores,1);
+        end
+        function [newDataFrame,params]=anchor(dataFrame,anchorFrame,anchorWeights)
+           %Convenience function that finds the 3D rotation/translation of dataFrame to best match the anchorFrame
+           %TODO: use weights to do a weighted optimization
+           [R,t,newDataFrame]=getTranslationAndRotation(dataFrame,anchorFrame);
+           params.R=R;
+           params.t=t;
+        end
+        function [markerScores]=untangleLikelihoods(L,indicatrix)
+            A=-indicatrix';
+            options = optimoptions('fmincon','Display','off','SpecifyObjectiveGradient',false,'OptimalityTolerance',1e-1,'StepTolerance',1e-1,'ConstraintTolerance',1e-1); %Relax tolerances for fast compute
+            options2 = optimoptions('linprog','Display','off');
+            N=size(indicatrix,1);
+            LB=zeros(N,1);
+            f=ones(N,1);
+            M=size(L,2); %number of frames
+            markerScores=nan(N,M);
+            display(['Running for ' num2str(M) ' frames. Expect ' num2str(M/75,2) ' sec. processing time (75 fps).'])
+            tic
+            for j=1:M
+               b=-sqrt(-2*L(:,j)); %transform likelihood to std away from expectation
+               %Get linear programming solution:
+               [x0,~,~,~,lam]=linprog(f,A,b,[],[],LB,[],options2); %Being used to identify active inequalities only
+               %f'*x0
+               %Sparsify solution: (for each active constraint, selecting the most
+               %unequal solution possible, notice this maintains the cost f'*x constant)
+               activeConstraints=(lam.ineqlin==1);
+               A1=-A(activeConstraints,:); %Active inequalities
+               idx=any(A1~=0); %For each marker there is at least 1 active inequality, or one of the bounds was reached
+               A2=A1(:,idx);
+               aux=fmincon(@(x) [-sum(x.^2)],x0(idx),A(~activeConstraints,idx),b(~activeConstraints),A2,A2*x0(idx),LB(idx),[],[],options);  %Notice this adds as constraint that active inequalities from linprog are maintained
+               x0(idx)=aux;
+               markerScores(:,j)=-.5*x0.^2;
+               %f'*x0 %Check that this was maintained
+            end
+            toc
+        end        
+        function [outMarkers]=untangleOutliers(outStats,in) %Single frame: L is vector
+            %Solve: min 1'*y s.t. L<=i'*y and y>=(i*L -1'*y), where L = outlier stats for marker
+            %This means we find the minimum outlier set, such that each
+            %outlier stat has at least one causing outlier marker AND any
+            %marker that has strictly more outlier stats than there are outlier
+            %markers is an outlier itself [I think this is implied by the other but am not sure].
+            [M,P]=size(in);
+            uno=ones(M,1);
+            cero=zeros(M,1);
+            f=[uno]; %Vector to solve y 
+            lb=[cero];
+            ub=[uno];
+            opts=optimoptions('intlinprog','Display','off');
+            outMarkers=(in*outStats)>1; %This marks markers only if they have more than one outlier stat
+            for j=1:size(outStats,2)
+                b1=outStats(:,j);
+                b2=in*outStats(:,j);
+                c=outMarkers(:,j);
+                if any(b1>in'*c) || any(c<(b2-sum(c))) || sum(c)>1 %Only run if the inequalities are not already satisified or if two markers were outliers in the same frame
+                    %Ineq 1: L<=i'*y -> -L>= -i'*y
+                    A1=-in';
+                    b1=-b1;
+                    %Ineq 2: y>=(i*L -1'*y)/K -> -y-(1'*y)/K<=-i*L/K
+                    K=max(sum(in,2));
+                    A2=[-eye(M)-ones(M)/K];
+                    b2=-b2/K;
+                    outMarkers(:,j)=intlinprog(f,[1:M],[A1;A2],[b1;b2],[],[],lb,ub,opts);
+                end
+            end
+        end 
+    end
+    methods(Static,Hidden)
+        function data=applyPermutationList(data,permutationList)
+            if size(data,1)==1 %Row vector
+                data=data(:);
+            end
+            %Applies a list of pair-wise permutations along dim 1
+            for i=1:size(permutationList,1)
+                data(permutationList(i,:),:)=data(fliplr(permutationList(i,:)),:);
+            end
+        end
+    end
+end
+

--- a/fun/ext/markerDataCleaning/models/naiveDistances.m
+++ b/fun/ext/markerDataCleaning/models/naiveDistances.m
@@ -1,0 +1,365 @@
+classdef naiveDistances < markerModel
+    %summary stats: pair-wise component differences
+    %model: independent normals
+
+    methods
+        function this = naiveDistances(trainData,labs)
+            this=this@markerModel(trainData,labs);
+            ss=this.getRobustStd(.94);
+            this.activeStats=ss<15 & ss<(this.statMean/2); %Why is the second cosntraint here?
+        end
+        function [logL,g] = loglikelihood(this,data)
+            ss=this.summaryStats(data);
+            %sigma=this.statStd;
+            sigma=this.getRobustStd(.94);
+            %mu=this.statMean;
+            mu=this.statMedian;
+            logL=markerModel.normalLogL(ss,mu,sigma);
+            logL(~this.activeStats,:)=0;
+            logL=logL(this.activeStats,:);
+            logL(isnan(logL))=0;
+            g=[];
+        end
+        function i = indicatrix(this,fullFlag,M) %MxP
+            if nargin<3 || isempty(M)
+                M=this.Nmarkers;
+            end
+            ind=triu(true(M),1);
+            i=nan(M,M*(M-1)/2);
+            for j=1:M
+                aux=zeros(M);
+                aux(:,j)=1;
+                aux(j,:)=1;
+                i(j,:)=aux(ind(:));
+            end
+            if nargin<2 || isempty(fullFlag) || fullFlag==false
+                i=i(:,this.activeStats); %Default
+            end
+        end
+        function fh=seeModel(this)
+           fh=this.seeModel@markerModel;
+           subplot(3,2,[2,4,6])
+           hold on
+           m=nanmedian(this.trainingData,3);
+           i=this.indicatrix;
+           sigma=this.getRobustStd(.94);
+           sigma=sigma(this.activeStats);
+           mu=this.statMedian(this.activeStats);
+                for j=1:size(i,2)
+                    %if this.activeStats(j)
+                    aux=find(i(:,j));
+                    n=mean(m(aux,:));
+                    for k=1:length(aux)
+                       plot3([n(1) m(aux(k),1)],[n(2) m(aux(k),2)],[n(3) m(aux(k),3)],'k')
+                    end
+                    text(n(1),n(2),n(3),['mu=' num2str(mu(j),3) ', sigma=' num2str(sigma(j),2)])
+                    %end
+                end
+        end
+        function [badFlag,mirrorOutliers,outOfBoundsOutlier] = validateMarkerModel(this,verbose)
+            %TODO: change this to load getRefData() and use the bounds from
+            %there as the ONLY source of testing. If that works well, move
+            %this function to markerModel(), since it won't have any class
+            %specific information, other than what getRefData() provides
+            %This function compares a trained model vs. a reference model
+            %of the class, and returns a potential list of markers with
+            %issues. It is meant to be used as a diagnostics tool to detect
+            %bad models (possibly caused by bad training data).
+            outOfBoundsOutlier=false(size(this.trainingData,1),1);
+            if nargin<2 || isempty(verbose)
+                verbose=true;
+            end
+            badFlag=false;
+            %Check three things:
+            %1) No marker is closer to a contralateral marker
+            %than its ipsilateral counterpart
+            %This requires L/R markers to be sorted properly
+            mu=naiveDistances.stat2Matrix(this.statMedian);
+            M=size(mu,1);
+            firstHalf=1:ceil(M/2);
+            secondHalf=ceil(M/2)+1:M;
+            mu1=triu(mu(firstHalf,firstHalf));
+            mu2=triu(fliplr(mu(firstHalf,secondHalf)));
+            mu3=triu(mu(secondHalf,secondHalf));
+            mu4=triu(flipud(mu(firstHalf,secondHalf)));
+            D=[mu2<mu1,zeros(size(mu1));zeros(size(mu1)),mu4<mu3] & mu([firstHalf secondHalf],[firstHalf secondHalf])<700; %Using 700mm as a threshold for distances to look at
+            %otherwise we compare something like RPSIS to RTOE and LTOE, which by geometry are almost equally far from RPSIS, and any movement or placement asymmetry will raise an alarm.
+            %Excluding SHANK and THIGH from this, since markers are not meant to be placed symmetrically
+            [bool,idxs] = compareListsNested(this.markerLabels,{'RTHI','LTHI','LTHIGH','RTHIGH','RSHANK','LSHANK','LSHA','RSHA','LSHNK','RSHNK'});
+            D(idxs(bool),:)=false;
+            D(:,idxs(bool))=false;
+            [outMarkers1]=markerModel.untangleOutliers( naiveDistances.distMatrix2stat(D),this.indicatrix(true));
+            if any(outMarkers1)
+                if verbose
+                fprintf(['Mislabeled markers. Contralat. distances > ipsilat. for: '])
+                fprintf([cell2mat(strcat(this.markerLabels(outMarkers1),', ')) '\n'])
+                end
+                badFlag=true;
+            end
+            mirrorOutliers=outMarkers1;
+
+            %2) The two (three?) closest markers (ipsilaterally along z-axis: as sorted before) to any given marker have std<10
+            sigma=naiveDistances.stat2Matrix(this.getRobustStd(.94));
+            if any(any(triu(sigma)-triu(sigma,3)))>10
+                if verbose
+                fprintf(['Too much variability for adjacent markers.\n'])
+                end
+                badFlag=true;
+            end
+
+            %3) No marker pair has a distance outside the admissible bounds
+            load distanceModelReferenceData.mat
+            [bool,idxs] = compareListsNested(this.markerLabels,markerLabels);
+            list1=this.markerLabels(idxs(bool));
+            list2=markerLabels(bool);
+            if ~all(strcmp(list1,list2))
+                error('Incompatible lists')
+            end
+            upperBound=upperBound(bool,bool);
+            lowerBound=lowerBound(bool,bool);
+            reducedMu=mu(idxs(bool),idxs(bool));
+            if any(any(reducedMu<lowerBound | reducedMu>upperBound))
+                D= zeros(size(mu));
+                D(idxs(bool),idxs(bool))= reducedMu<lowerBound | reducedMu>upperBound;
+                in=this.indicatrix(true);
+                [outMarkers2]=markerModel.untangleOutliers(naiveDistances.distMatrix2stat(D),in);
+                if verbose
+                fprintf(['Marker distances above or below the allowed limits for markers: '])
+                fprintf([cell2mat(strcat(this.markerLabels(outMarkers2),', ')) '\n'])
+                end
+            %                             [ii,jj]=find(reducedMu<lowerBound | reducedMu>upperBound);
+            %                             for i1=1:length(ii)
+            %                                disp(['Mean distance from ' distanceModel.markerLabels{ii(i1)} ' to ' distanceModel.markerLabels{jj(i1)} ' (' num2str(reducedMu(ii(i1),jj(i1)),3) 'mm) exceeds limits [' num2str(lowerBound(ii(i1),jj(i1)),3) ', ' num2str(upperBound(ii(i1),jj(i1)),3) 'mm].'])
+            %                             end
+                badFlag=true;
+                outOfBoundsOutlier=outMarkers2;
+             end
+
+        end
+        function [permutationList,newModel] = permuteModelLabels(model)
+            %Checks if a model is invalid, and if it is, tries to find label
+            %permutations that would make it valid.
+            %TO DO: can this be achieved by just finding permutations of
+            %the training data of the model against the reference model? If
+            %so we can avoid duplicating code.
+            %Iny any case, this can be moved to markerModel()
+            %See also: naiveDistances.validateMarkerModel markerModel.validateMarkerModel
+
+            [~,mirrorOutliers,outOfBoundsOutlier] = model.validateMarkerModel(false);
+            nBad=sum(mirrorOutliers | outOfBoundsOutlier);
+            nBinit=nBad;
+            newModel=model;
+            %if nBad>10 %Too many permutations, search is not feasible
+            %    error('Too many possible permutations, search is not feasible')
+            %end
+
+            %First try with permutations of markers marked as bad:
+            permutationList=nan(0,2);
+            if nBad>1 && any(mirrorOutliers)
+                [newModel,permutationList,nBad]=tryPermutations(newModel,find(mirrorOutliers));
+            end
+
+            %Second: if there are still bad things, try with permutations of mirror outliers OR outOfBounds
+            if nBad>1
+                [~,mirrorOutliers,outOfBoundsOutlier] = validateMarkerModel(newModel,false);
+                [newModel,permutationList2,nBad]=tryPermutations(model,find(mirrorOutliers | outOfBoundsOutlier));
+                permutationList=[permutationList;permutationList2];
+            end
+
+            %Third: try with permutations of everything (possibly unfeasible because of number of permutations to try)
+            %if nBad>0
+            %    [~,mirrorOutliers,outOfBoundsOutlier] = validateMarkerModel(model,false);
+            %    [newModel,permutationList2,nBad]=tryPermutations(model,find(mirrorOutliers | outOfBoundsOutlier));
+            %    permutationList=[permutationList;permutationList2];
+            %end
+
+            if nBad==0 %No issues remain
+                %disp('Success! Found permutation that fixes issues.')
+            elseif nBad<nBinit
+                %warning('Improved results through permutation, but some issues remain.')
+            else
+                %warning('No improvement was found')
+                permutationList=[];
+                newModel=model;
+            end
+        end
+        function newModel=applyPermutation(model,permutation)
+            %TODO: applying a permutation should require to only permute labels.
+            % Also, if this function is needed, should be in markerModel superclass
+            newModel=model;
+            %First, permute the training data:
+            for i=1:size(permutation,1)
+                newModel.trainingData(permutation(i,:),:,:)=newModel.trainingData(fliplr(permutation(i,:)),:,:);
+            end
+            %Inefficient: re-train
+            newModel = naiveDistances(newModel.trainingData,newModel.markerLabels);
+            %Efficient:...
+        end
+        function mleData=reconstruct(this,data,dataPriors,fastFlag)
+            %INPUTs:
+            %this: a model
+            %data: M (markers) x3(dim) xN (frames)
+            %priors: MxN or Mx1 matrix containing the uncertainty (std) in positions we think we have: assumes spherical uncertainty
+            [M,D,N]=size(data);
+            if nargin<3 || isempty(dataPriors)
+               %Assume that priors are each marker's score according to this same model
+               %priors=...
+               dataPriors=ones(M,N);
+            end
+            if nargin<4 || isempty(fastFlag)
+                fastFlag=false;
+            end
+            mleData=nan(size(data));
+            wD=1./this.getRobustStd(.94).^2;
+            wD(wD>1)=1; %Don't trust any distance TOO much
+            lastSol=[];
+            for k=1:N
+                %TODO: for speed, only run if at least one dataPrior is
+                %larger than X mm (ie. if we are certain about ALL markers,
+                %there is nothing to optimize for).
+                %TODO: based on training data, estimate a decent threshold
+                %for the cost function of the reconstruction
+                wP=1./dataPriors(:,k).^2;
+                wP(wP>1)=1; %Don't trust any position TOO much, leads to bad numerical properties
+                lastSol=naiveDistances.invertAndAnchor(this.statMean,data(:,:,k),wP,wD,lastSol,fastFlag);
+                mleData(:,:,k)=lastSol;
+            end
+%Validate result:
+%             logLBefore=this.loglikelihood(data);
+%             outlierBefore=this.outlierDetectFast(data);
+%             logLAfter=this.loglikelihood(mleData);
+%             outlierAfter=this.outlierDetectFast(mleData);
+%             if any(outlierAfter & ~outlierBefore) || any((logLAfter<logLBefore) & (logLAfter<-5))
+%                 warning('Reconstruction made some things worse: this is not working.')
+%             end
+%             if any(outlierAfter)
+%                 warning('Reconstruction did not remove all outliers: try reducing confidence in original measurements')
+%             end
+        end
+    end
+    methods(Hidden)
+%         function [model,permutationList,nBad]=tryPermutations(model,listToPermute)
+%             %TODO: test this agains markerModel.tryPermutations() and see
+%             %which one performs best & fastest. If not this one, deprecate.
+% 
+%             %Overload!
+%             permutationList=zeros(0,2);
+%             %Benchmark to compare:
+%             [~,mirrorOutliers,outOfBoundsOutlier] = validateMarkerModel(model,false);
+%             nBad=sum(mirrorOutliers | outOfBoundsOutlier);
+% 
+%             while nBad>0
+%                 %Permutations to consider:
+%                 listOfPermutations=nchoosek(listToPermute,2);
+%                 N=size(listOfPermutations,1);
+%                 count=0;
+%                 while count<N
+%                    count=count+1;
+%                    modelAux=applyPermutation(model,listOfPermutations(count,:)); %Permute
+%                    [~,newMO,newOBO] = validateMarkerModel(modelAux,false);
+%                    newNB=sum(newMO | newOBO);
+%                    if newNB<nBad %Found permutation that improves things
+%                        break
+%                    end
+%                 end
+%                 if newNB>=nBad %Checking if while exited without making any improvements
+%                     return
+%                 else %Improvement was made!
+%                     %New benchmark:
+%                     model=modelAux;
+%                     [~,mirrorOutliers,outOfBoundsOutlier] = validateMarkerModel(model,false);
+%                     nBad=sum(mirrorOutliers | outOfBoundsOutlier);
+%                     permutationList=[permutationList;listOfPermutations(count,:)]; %Adding permutation to list
+%                 end
+%             end
+%         end
+        function dataFrame=invertAndAnchor(ss,anchorFrame,anchorWeights,distanceWeights,initGuess,fastFlag)
+            knownDistances=naiveDistances.stat2DistMatrix(ss);
+            distanceWeights=naiveDistances.stat2DistMatrix(distanceWeights);
+            if nargin<6 || isempty(fastFlag)
+                fastFlag=false;
+            end
+            if ~fastFlag
+                [dataFrame] = getPositionFromDistances_v3(anchorFrame,knownDistances,anchorWeights,distanceWeights,initGuess);
+            else
+                %Option 1:
+                %knownDistances=stat2DistMatrix(ss);
+                %[dataFrame] = getPositionFromDistances_v2(anchorFrame,knownDistances,anchorWeights,anchorFrame);
+                %Option 2:
+                %Divide markers in certain and uncertain. Certain markers are
+                %offered as knownPositions and NOT optimized for.
+                %Uncertain markers are optimized for, and have no known positions
+                dataFrame=anchorFrame; 
+                fixedMarkers=anchorWeights>=.5 | isnan(anchorWeights) | anchorWeights==Inf; %Arbitrary threshold
+                if any(~fixedMarkers)
+                    anchorFrame=anchorFrame(fixedMarkers,:);
+                    knownDistances=knownDistances(fixedMarkers,~fixedMarkers);
+                    distanceWeights=distanceWeights(fixedMarkers,~fixedMarkers);
+                    anchorWeights=anchorWeights(~fixedMarkers);
+                    if ~isempty(initGuess)
+                        initGuess=initGuess(~fixedMarkers,:);
+                    end
+                    %TODO: 
+                    %Do the optimization one marker at a time. May be slower, but better conditioned.
+                    %After optimizing: check that the result is decent (no outlier markers remain)
+                    [aux] = getPositionFromDistances_v3(anchorFrame,knownDistances,zeros(size(anchorWeights)),distanceWeights,initGuess);
+                    dataFrame(~fixedMarkers,:)=aux;
+                end
+            end
+        end
+    end
+    methods(Static)
+        %Implementing superclass required methods:
+        function [ss,g] = summaryStats(data)
+           D=computeDistanceMatrix(data);
+           ss=naiveDistances.distMatrix2stat(D);
+           if nargout>2
+              g=[]; %TODO
+           end
+        end
+        function this = learn(data,labels,noDisp)
+            if nargin<2
+                labels={};
+            end
+            this=naiveDistances(data,labels);
+            if nargin<3 || isempty(noDisp) || ~noDisp
+                this.seeModel()
+            end
+
+        end
+        function [D,xl,yl]=stat2Matrix(ss)
+            D=triu(naiveDistances.stat2DistMatrix(ss));
+            xl='markerLabels';
+            yl='markerLabels';
+        end
+        function [model,meanLB,meanUB,stdLB,stdUB,A,b]=getRefData()
+            [model,lowerBound,upperBound]=load('../data/distanceModelReferenceData.mat');
+            meanLB=naiveDistances.distMatrix2stat(lowerBound);
+            meanUB=naiveDistances.distMatrix2stat(upperBound);
+            stdLB=zeros(size(meanLB));
+            stdUB=Inf*ones(size(meanLB));
+            A=zeros(0,size(meanLB,2));
+            b=zeros(0,1);
+        end
+
+        %Subclass-specific functions:
+        function D=stat2DistMatrix(ss)
+            %ss is M(M-1)/2 x N
+            M=ceil(sqrt(2*size(ss,1)));
+            N=size(ss,2);
+            ind=triu(true(M),1);
+            D=zeros(M^2,N);
+            D(ind,:)=ss;
+            D=reshape(D,M,M,N);
+            D=D+permute(D,[2,1,3]);
+        end
+        function ss=distMatrix2stat(D)
+           %D can be MxM or MxMxN
+           M=size(D,1);
+           N=size(D,3);
+           ss=reshape(D,M^2,N);
+           ind=triu(true(M),1);
+           ss=ss(ind(:),:); %Keeping only upper half: PxN, with P=M*(M-1)/2
+        end
+    end
+end

--- a/fun/ext/markerDataCleaning/old_markerModels/createZeroModel.m
+++ b/fun/ext/markerDataCleaning/old_markerModels/createZeroModel.m
@@ -1,0 +1,39 @@
+function [D,sD,meanPos,biasPos] = createZeroModel(inputData)
+%UNTITLED6 Summary of this function goes here
+%   Detailed explanation goes here
+
+if isa(inputData,'char') %Assume it is the name of a .c3d file
+    %Load c3d using btk, to be done
+elseif isa(inputData,'orientedLabTimeSeries') %Assume it is a timeseries containing 3D data
+    X=inputData.getOrientedData;
+else %Assume it is a Nx3xM matrix
+   X=inputData; 
+end
+
+[N,dim,M]=size(X);
+dist=nan(N,N,M);
+for i=1:M
+    dist(:,:,i)=computeDistanceMatrix(X(:,:,i));
+end
+
+
+
+%D=trimmean(dist,10,'round',3); %Mean across 3rd dim, trimming 10% of extreme values
+D=nanmedian(dist,3);
+sD=1.4826*mad(dist,1,3); %Computes the median absolute deviation, as a more robust estimation of std() when outliers are present. 1.48 is the factor between sigma and mad in a normal dist
+
+
+meanPos=nanmedian(inputData,3);
+
+if nargout>3
+    altPos=nan(size(inputData));
+    for i=1:size(inputData,3)
+        [altPos(:,:,i)] = getBestReconsFromZeroModel(inputData(:,:,i),D,sD,meanPos);
+    end
+    biasPos=nanmean(altPos-inputData,3);
+else
+    biasPos=zeros(N,dim);
+end
+
+end
+

--- a/fun/ext/markerDataCleaning/old_markerModels/determineLikelihoodFromZeroModel.m
+++ b/fun/ext/markerDataCleaning/old_markerModels/determineLikelihoodFromZeroModel.m
@@ -1,0 +1,44 @@
+function [lp,p] = determineLikelihoodFromZeroModel(X,D,sD)
+%Computes a likelihood for a set of marker positions given a 'zero-model'
+%(naive bayes) which assumes independent gaussian distributions for each
+%distance between models. 
+%------
+%INPUTS:
+%X is a Nx3xM matrix of N marker positions in 3D, samples M times.
+%D is a NxN matrix containing the expected distances between the N markers
+%sD is a NxN matrix containing the standard deviation of the distances
+%across time
+%------
+%OUTPUT:
+%p is a NxM matrix containing log-likelihoods for each of the N markers in each
+%of the M samples
+
+[N,tres,M]=size(X);
+if size(D,1)~=N || ~issquare(D)
+    error()
+end
+if size(sD,1)~=N || ~issquare(sD)
+    error()
+end
+if tres~=3
+    error()
+end
+
+lp=nan(N,M);
+%D=D+eye(size(D));
+%sD=sD+eye(size(D));
+for i=1:M %For each frame
+   dist=computeDistanceMatrix(X(:,:,i));
+   pp=(-(dist(:)-D(:)).^2./(2*sD(:).^2));%./(sqrt(2*pi)*sD(:)); %Fake log-likelihood: it is a mahalanobis distance squared
+   pp=reshape(pp,N,N);
+   lp(:,i)=nanmean(-sqrt(-pp));
+end
+
+p=[];
+
+end
+
+function bool=issquare(D)
+bool = size(D,1)==size(D,2);
+end
+

--- a/fun/ext/markerDataCleaning/old_markerModels/getBestReconsFromZeroModel.m
+++ b/fun/ext/markerDataCleaning/old_markerModels/getBestReconsFromZeroModel.m
@@ -1,0 +1,44 @@
+function [altPos] = getBestReconsFromZeroModel(measuredPos,D,sD,meanPos,markersForReconstruction,biasPos)
+%UNTITLED Summary of this function goes here
+%   Detailed explanation goes here
+X2=measuredPos;
+[~,~,x0]=getRotationAndTranslation(meanPos(1:size(measuredPos,1),:),measuredPos);
+
+if nargin<5 || isempty(markersForReconstruction) %If marker list not given, reconstructing everything
+    markersForReconstruction=1:size(measuredPos,1);
+end
+X2alt=X2;
+if nargin<6 || isempty(biasPos)
+    biasPos=zeros(size(measuredPos));
+end
+
+measuredLike=determineLikelihoodFromZeroModel(X2alt,D,sD);
+measuredLike(isnan(measuredLike))=-1e3;
+[~,markerOrder]=sort(measuredLike(markersForReconstruction),1,'ascend'); %Sorting likelihoods of measuredMarkers that need to be reconstructed
+lp=determineLikelihoodFromZeroModel(measuredPos,D,sD);
+
+kP=X2;
+kD=D(:,markersForReconstruction);
+sD2=sD+diag(nan*diag(sD));
+sD=sqrt(sD.^2+0); %Adding some uncertainty for measurement errors (?)
+selfSD=min(sD2,[],1).*exp((lp+1));
+%Weight for same-marker will be inversely related to likelihood of measurement. Likelihood ~-1 weights measurement as the best reference marker, -2 weights it 1/e, -3 weights it 1/e^2
+selfSD=1e3*ones(size(selfSD))
+kSD=sD+diag(selfSD); 
+kSD=kSD(:,markersForReconstruction);
+    
+for i=1:length(markerOrder)
+    marker=markersForReconstruction(markerOrder(i)); %Marker to reconstruct
+    
+    w=1./kSD(:,marker); 
+    w=w/nansum(w);
+    wS=sort(w,'descend');
+    
+    idx=any(isnan(kP),2) | isnan(kD(:,marker)) | isnan(w) | (w<(1/length(w)) & w<wS(4)); %Eliminating missing markers & very-low weights (preserving at least 4 reference markers)
+    [X2alt(marker,:)] = getPositionFromDistances(kP(~idx,:),kD(~idx,marker),w(~idx),x0(marker,:)); %Estimated reconstruction
+    kP=X2alt; %Update
+end
+altPos=X2alt+biasPos;
+
+end
+

--- a/fun/ext/markerDataCleaning/staticSkeleton/sk3Ddetect.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/sk3Ddetect.m
@@ -1,0 +1,23 @@
+function [markerLogL,totalLogL] = sk3Ddetect(data,m,R)
+[N,d,M]=size(data);
+[D] = computeDiffMatrix(data); %Will be NxdxNxM
+missing=squeeze(any(isnan(data),2));
+clear data
+D=permute(D,[1,3,2,4]); %NxNxdxM
+R=reshape(R,N,N,d);
+D=D-m; %Subtracting mean
+C=R+1e3*max(abs(R(:)))*eye(N);
+auxScores=D.^2 ./C;
+
+
+
+totalLogL=squeeze(nanmean(nanmean(nanmean(auxScores))));
+%markerLogL=nan(N,M);
+markerLogL=squeeze(nanmedian(reshape(auxScores,N,N*d,M),2));
+%markerLogL=squeeze(mean(reshape(auxScores,N,N*d,M),2));
+
+
+markerLogL(missing)=-10;
+
+end
+

--- a/fun/ext/markerDataCleaning/staticSkeleton/sk3Denforce.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/sk3Denforce.m
@@ -1,0 +1,20 @@
+function [xMLE] = sk3Denforce(x,P,s,R)
+%Given a prior estimate x with uncertainty P (normal dist) of some variable x, and the
+%relative position model given by s, R [W*x~N(s,diag(R))], computes the optimal
+%(bayesian) estimate of x
+%If elements of x are NaN, they are considered 'missing' and assigned an
+%arbitrary value with (numerically) infinite uncertainty
+[N,D]=size(x);
+W = computeDiffMatrix(N);
+Z=sparse(zeros(size(W)));
+
+%Deal with NaNs in data:
+idx=isnan(x(:));
+x(idx)=0;
+aux=zeros(N*D,1);
+aux(idx)=1;
+P=P+1e15*max(P(:))*diag(aux);
+
+[xMLE,PMLE]=updateKF([W Z Z;Z W Z; Z Z W],diag(R(:)),x(:),P,s(:),zeros(size(W,1)*D,1)); %Optimal bayesian update
+end
+

--- a/fun/ext/markerDataCleaning/staticSkeleton/sk3Dlearn.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/sk3Dlearn.m
@@ -1,0 +1,12 @@
+function [m,R] = sk3Dlearn(pos)
+%Returns model such that W*pos(:,:,i) ~ N(m,R)
+[N,d,M]=size(pos);
+[D] = computeDiffMatrix(pos); %Will be NxdxNxM
+D=permute(D,[1,3,2,4]); %NxNxdxM
+m=nanmean(D,4);
+R=nan(N,N*d); %Naive bayes
+for i=1:N %For each marker, compute mean vector, and its cov
+    R(i,:)=nanvar(reshape(D(i,:,:,:),N*d,M),[],2); %Nx(Nd)x(Nd)
+end
+
+end

--- a/fun/ext/markerDataCleaning/staticSkeleton/skDistdetect.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/skDistdetect.m
@@ -1,0 +1,15 @@
+function [markerLogL,totalLogL] = skDistdetect(data,m,R)
+[N,d,M]=size(data);
+[D] = computeDistanceMatrix(data); %Will be NxNxM
+missing=squeeze(any(isnan(data),2));
+clear data
+D=D-m; %Subtracting mean
+C=R+1e3*max(abs(R(:)))*eye(N);
+auxScores=D.^2 ./C;
+totalLogL=squeeze(nanmean(nanmean(nanmean(auxScores))));
+%markerLogL=nan(N,M);
+markerLogL=squeeze(nanmedian(reshape(auxScores,N,N,M),2));
+%markerLogL=squeeze(mean(reshape(auxScores,N,N*d,M),2));
+markerLogL(missing)=-10;
+
+end

--- a/fun/ext/markerDataCleaning/staticSkeleton/skDistenforce.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/skDistenforce.m
@@ -1,0 +1,69 @@
+function [xMLE] = skDistlearnenforce(x,P,s,R)
+%Given a prior estimate x with uncertainty P (normal dist) of some variable x, and the
+%relative position model given by s, R [W*x~N(s,diag(R))], computes the optimal
+%(bayesian) estimate of x
+%If elements of x are NaN, they are considered 'missing' and assigned an
+%arbitrary value with (numerically) infinite uncertainty
+[N,d]=size(x);
+
+%Deal with NaNs in data:
+idx=isnan(x(:));
+x(idx)=0;
+aux=zeros(N*d,1);
+aux(idx)=1;
+P=P+1e15*max(P(:))*diag(aux);
+
+%Iterate: linearize, find optimal solution
+endFlag=false;
+changeTh=1e-3;
+xMLE=x(:); %Nd x 1
+%Reshaping parameters for updateKF:
+y=zeros(N^2,1);s=s(:);R=diag(R(:));x=x(:);
+lastXMLE=x; %Init guess
+iter=0;
+maxIter=25;
+while ~endFlag && iter<maxIter
+  %Linearize distance constraints:
+  [off,W]=linearizeDist(reshape(lastXMLE,N,d));
+  %Optimal bayesian solution around linearized point:
+  [xMLE,PMLE]=updateKF(W,R,x,P,s-off(:),y);
+  change=sqrt(sum((xMLE-lastXMLE(:)).^2));
+  endFlag=change<changeTh;
+  lastXMLE=xMLE;
+  iter=iter+1;
+end
+end
+
+function [Do,W]=linearizeDist(xo)
+  %Computes an approximation of the function
+  %D=computedDistanceMatrix(x) around x=xo
+  %As: D(:) ~ Do(:) + W*x(:)
+  %Assumed xo is Nxd
+  [N,d]=size(xo);
+  D=computeDistanceMatrix(xo);
+  G1=reshape(xo,N,1,d)./(D+eye(N));
+  G2=reshape(xo,1,N,d)./(D+eye(N));
+  W1=zeros(N,N,N,d);
+  W2=zeros(N,N,N,d);
+  for i=1:N
+    W1(i,:,i,:)=G1(:,i,:);
+    W2(:,i,i,:)=G2(:,i,:);
+  end
+  %Need to reshape G/pad with 0's, so W is NxNxNd
+  W=W1-W2; %NxNxNxd
+  W=reshape(W,N^2,N*d);
+  Do=D-reshape(W*xo(:),N,N); %NxN
+end
+
+function testLinearization(xo)
+D=computeDistanceMatrix(xo);
+[Do,W]=linearizeDist(xo);
+e=1e-3;
+p=e*randn(size(xo));
+x=xo+p;
+D1=computeDistanceMatrix(x);
+D1app=Do(:)+W*x(:);
+
+%Check: D1 ~ D1app
+norm(D1(:)-D1app) %Should be very small
+end

--- a/fun/ext/markerDataCleaning/staticSkeleton/skDistlearn.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/skDistlearn.m
@@ -1,0 +1,11 @@
+function [m,R] = skDistlearn(pos)
+%Returns model such that W*d(pos(:,:,i)) ~ N(m,R)
+%W is a selection matrix to reduce complexity
+[N,d,M]=size(pos);
+[D] = computeDistanceMatrix(pos); %NxNxM
+m=nanmean(D,3);
+R=nan(N,N); %Naive bayes
+for i=1:N %For each marker, compute mean vector, and its cov
+    R(i,:)=nanvar(reshape(D(i,:,:),N,M),[],2); %Nx(N)x(Nd)
+end
+end

--- a/fun/ext/markerDataCleaning/staticSkeleton/testSkeleton.m
+++ b/fun/ext/markerDataCleaning/staticSkeleton/testSkeleton.m
@@ -1,0 +1,24 @@
+%testSkeleton
+
+%% Load some data
+pos=10*randn(54,5)*randn(5,1000) + randn(54,1000);
+pos=reshape(pos,18,3,1000);
+[N,D,M]=size(pos);
+%% LEarn skeleton
+[m,R] = sk3Dlearn(pos);
+
+%% Enforce it
+P=eye(N*D);
+xMLE=nan(N*D,M);
+for i=1:M
+    i
+    [xMLE(:,i)] = sk3Denforce(reshape(pos(:,:,i),N*D,1),P,m(:),R,W);
+end
+
+%% Compare
+
+
+xMLE=reshape(xMLE,N,D,M);
+
+err=xMLE-pos;
+imagesc(mean(err,3))

--- a/fun/ext/pitools/LICENSE
+++ b/fun/ext/pitools/LICENSE
@@ -1,0 +1,339 @@
+GNU GENERAL PUBLIC LICENSE
+                       Version 2, June 1991
+
+ Copyright (C) 1989, 1991 Free Software Foundation, Inc.,
+ 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+License is intended to guarantee your freedom to share and change free
+software--to make sure the software is free for all its users.  This
+General Public License applies to most of the Free Software
+Foundation's software and to any other program whose authors commit to
+using it.  (Some other Free Software Foundation software is covered by
+the GNU Lesser General Public License instead.)  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+this service if you wish), that you receive source code or can get it
+if you want it, that you can change the software or use pieces of it
+in new free programs; and that you know you can do these things.
+
+  To protect your rights, we need to make restrictions that forbid
+anyone to deny you these rights or to ask you to surrender the rights.
+These restrictions translate to certain responsibilities for you if you
+distribute copies of the software, or if you modify it.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must give the recipients all the rights that
+you have.  You must make sure that they, too, receive or can get the
+source code.  And you must show them these terms so they know their
+rights.
+
+  We protect your rights with two steps: (1) copyright the software, and
+(2) offer you this license which gives you legal permission to copy,
+distribute and/or modify the software.
+
+  Also, for each author's protection and ours, we want to make certain
+that everyone understands that there is no warranty for this free
+software.  If the software is modified by someone else and passed on, we
+want its recipients to know that what they have is not the original, so
+that any problems introduced by others will not reflect on the original
+authors' reputations.
+
+  Finally, any free program is threatened constantly by software
+patents.  We wish to avoid the danger that redistributors of a free
+program will individually obtain patent licenses, in effect making the
+program proprietary.  To prevent this, we have made it clear that any
+patent must be licensed for everyone's free use or not licensed at all.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                    GNU GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License applies to any program or other work which contains
+a notice placed by the copyright holder saying it may be distributed
+under the terms of this General Public License.  The "Program", below,
+refers to any such program or work, and a "work based on the Program"
+means either the Program or any derivative work under copyright law:
+that is to say, a work containing the Program or a portion of it,
+either verbatim or with modifications and/or translated into another
+language.  (Hereinafter, translation is included without limitation in
+the term "modification".)  Each licensee is addressed as "you".
+
+Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running the Program is not restricted, and the output from the Program
+is covered only if its contents constitute a work based on the
+Program (independent of having been made by running the Program).
+Whether that is true depends on what the Program does.
+
+  1. You may copy and distribute verbatim copies of the Program's
+source code as you receive it, in any medium, provided that you
+conspicuously and appropriately publish on each copy an appropriate
+copyright notice and disclaimer of warranty; keep intact all the
+notices that refer to this License and to the absence of any warranty;
+and give any other recipients of the Program a copy of this License
+along with the Program.
+
+You may charge a fee for the physical act of transferring a copy, and
+you may at your option offer warranty protection in exchange for a fee.
+
+  2. You may modify your copy or copies of the Program or any portion
+of it, thus forming a work based on the Program, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) You must cause the modified files to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    b) You must cause any work that you distribute or publish, that in
+    whole or in part contains or is derived from the Program or any
+    part thereof, to be licensed as a whole at no charge to all third
+    parties under the terms of this License.
+
+    c) If the modified program normally reads commands interactively
+    when run, you must cause it, when started running for such
+    interactive use in the most ordinary way, to print or display an
+    announcement including an appropriate copyright notice and a
+    notice that there is no warranty (or else, saying that you provide
+    a warranty) and that users may redistribute the program under
+    these conditions, and telling the user how to view a copy of this
+    License.  (Exception: if the Program itself is interactive but
+    does not normally print such an announcement, your work based on
+    the Program is not required to print an announcement.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Program,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Program, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Program.
+
+In addition, mere aggregation of another work not based on the Program
+with the Program (or with a work based on the Program) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may copy and distribute the Program (or a work based on it,
+under Section 2) in object code or executable form under the terms of
+Sections 1 and 2 above provided that you also do one of the following:
+
+    a) Accompany it with the complete corresponding machine-readable
+    source code, which must be distributed under the terms of Sections
+    1 and 2 above on a medium customarily used for software interchange; or,
+
+    b) Accompany it with a written offer, valid for at least three
+    years, to give any third party, for a charge no more than your
+    cost of physically performing source distribution, a complete
+    machine-readable copy of the corresponding source code, to be
+    distributed under the terms of Sections 1 and 2 above on a medium
+    customarily used for software interchange; or,
+
+    c) Accompany it with the information you received as to the offer
+    to distribute corresponding source code.  (This alternative is
+    allowed only for noncommercial distribution and only if you
+    received the program in object code or executable form with such
+    an offer, in accord with Subsection b above.)
+
+The source code for a work means the preferred form of the work for
+making modifications to it.  For an executable work, complete source
+code means all the source code for all modules it contains, plus any
+associated interface definition files, plus the scripts used to
+control compilation and installation of the executable.  However, as a
+special exception, the source code distributed need not include
+anything that is normally distributed (in either source or binary
+form) with the major components (compiler, kernel, and so on) of the
+operating system on which the executable runs, unless that component
+itself accompanies the executable.
+
+If distribution of executable or object code is made by offering
+access to copy from a designated place, then offering equivalent
+access to copy the source code from the same place counts as
+distribution of the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  4. You may not copy, modify, sublicense, or distribute the Program
+except as expressly provided under this License.  Any attempt
+otherwise to copy, modify, sublicense or distribute the Program is
+void, and will automatically terminate your rights under this License.
+However, parties who have received copies, or rights, from you under
+this License will not have their licenses terminated so long as such
+parties remain in full compliance.
+
+  5. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Program or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Program (or any work based on the
+Program), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Program or works based on it.
+
+  6. Each time you redistribute the Program (or any work based on the
+Program), the recipient automatically receives a license from the
+original licensor to copy, distribute or modify the Program subject to
+these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties to
+this License.
+
+  7. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Program at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Program by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Program.
+
+If any portion of this section is held invalid or unenforceable under
+any particular circumstance, the balance of the section is intended to
+apply and the section as a whole is intended to apply in other
+circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system, which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  8. If the distribution and/or use of the Program is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Program under this License
+may add an explicit geographical distribution limitation excluding
+those countries, so that distribution is permitted only in or among
+countries not thus excluded.  In such case, this License incorporates
+the limitation as if written in the body of this License.
+
+  9. The Free Software Foundation may publish revised and/or new versions
+of the General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Program
+specifies a version number of this License which applies to it and "any
+later version", you have the option of following the terms and conditions
+either of that version or of any later version published by the Free
+Software Foundation.  If the Program does not specify a version number of
+this License, you may choose any version ever published by the Free Software
+Foundation.
+
+  10. If you wish to incorporate parts of the Program into other free
+programs whose distribution conditions are different, write to the author
+to ask for permission.  For software which is copyrighted by the Free
+Software Foundation, write to the Free Software Foundation; we sometimes
+make exceptions for this.  Our decision will be guided by the two goals
+of preserving the free status of all derivatives of our free software and
+of promoting the sharing and reuse of software generally.
+
+                            NO WARRANTY
+
+  11. BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+  12. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+convey the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    
+    Copyright (C) 2013  pabloi
+
+    This program is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License along
+    with this program; if not, write to the Free Software Foundation, Inc.,
+    51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+Also add information on how to contact you by electronic and paper mail.
+
+If the program is interactive, make it output a short notice like this
+when it starts in an interactive mode:
+
+    Gnomovision version 69, Copyright (C) year name of author
+    Gnomovision comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, the commands you use may
+be called something other than `show w' and `show c'; they could even be
+mouse-clicks or menu items--whatever suits your program.
+
+You should also get your employer (if you work as a programmer) or your
+school, if any, to sign a "copyright disclaimer" for the program, if
+necessary.  Here is a sample; alter the names:
+
+  Yoyodyne, Inc., hereby disclaims all copyright interest in the program
+  `Gnomovision' (which makes passes at compilers) written by James Hacker.
+
+  {signature of Ty Coon}, 1 April 1989
+  Ty Coon, President of Vice
+
+This General Public License does not permit incorporating your program into
+proprietary programs.  If your program is a subroutine library, you may
+consider it more useful to permit linking proprietary applications with the
+library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.

--- a/fun/ext/pitools/dimReduction/myNNMF.m
+++ b/fun/ext/pitools/dimReduction/myNNMF.m
@@ -1,0 +1,47 @@
+function [W,C,d] = myNNMF(data,rank,reps,useParallel)
+%myNNMF Customized call to NNMF to get more consistent results
+%This function calls nnmf with custom params:
+%INPUTS:
+%data is the matrix to be factorized
+%rank is the desired rank of the factorization (dimensionality)
+%useParallel defines whether to use parallel computation
+%------------------------------------------------------------------------
+%CUSTOM PARAMS:
+%tolF is a % error that will be accepted as the min increment to say that
+%convergence has been achieved
+%tolX is 
+
+if nargin<4
+    useParallel='always';
+end
+if nargin<3
+    reps=8;
+end
+
+if size(data,1)<size(data,2)
+    data=data';
+end
+
+if rank==0
+    disp('There are no possible factorizations of rank 0, returning')
+    return
+elseif rank==size(data,2)
+    %disp('Full rank factorization: returning original matrix.')
+    C=eye(size(data,2));
+    W=data;
+    d=0;
+    return
+end
+
+nm=numel(data);
+alg='als'; %Should verify this is the best choice
+tolF=sqrt(.0001*norm(data,'fro')^2/(nm*(rank^2))) + eps; % 0.1% tolerance in objective function (note that this is 1/1000th of the max value for the tolerance function F)divided by desired rank squared.
+tolX=0.0001; %This is as a percentage (0.01%). It will determine convergence if the element that changes the most in W or H changes less than 0.01% of the highest element in those matrices.
+
+opts=statset('TolFun',tolF,'TolX',tolX,'UseParallel',useParallel,'Display','off');
+
+[W,C,d]=nnmf(data,rank,'replicates',reps,'algorithm',alg,'options',opts);
+
+
+end
+

--- a/fun/ext/pitools/dimReduction/ppcaLikelihood.m
+++ b/fun/ext/pitools/dimReduction/ppcaLikelihood.m
@@ -1,0 +1,52 @@
+function [logL] = ppcaLikelihood(data,coeff,latents,mu)
+%ppcaLikelihood Returns the likelihood of the pca result based on the
+%probabilistic pca analysis. Coeff and scores should be obtained through
+%the function pca. This is useful to analyze the intrinsic dimensionality
+%of a data set.
+
+%Parameters are such that data'=repmat(mu,N,1)+coeff'*scores + e;
+
+if nargin<4 %In this case, assuming either the data had exactly zero mean or the analysis performed was on uncentered data and hence the mean parameter is by definition useless.
+    mu=zeros(1,size(data,2));
+end
+
+
+N=size(data,1); %Sample size
+D=size(data,2); %Sample dimensionality
+k=size(coeff,1); %Number of components in reduced dimensionality space (reduced dim)
+
+
+%Just in case: normalize so that the coeffs have norm=1
+for i=1:k
+   coeff(i,:)=coeff(i,:)/norm(coeff(i,:)); 
+end
+
+centData=data-repmat(mu,N,1);
+S=centData'*centData/N;
+if k<D %If k==D there is no need to do anything, the model makes no sense anyway. Returning NaN.
+    sigma=sqrt(sum(latents(k+1:D))/(D-k));
+
+
+    W=(coeff'*diag(sqrt(latents(1:k)-sigma^2)))'; %Eigen vectors are scaled by the sqrt(\lambda-sigma^2), which roughly means they are scaled by the standard deviation along that direction, discounting the portion of the variance that is attributed to noise.
+
+
+    M=W*W' + sigma^2*eye(k);
+    bb=svd(W');
+    eigM=bb.^2 + sigma^2; %This should be exactly latents(1:k)
+
+    Cinv=(eye(D)- W'*(M\W))/sigma^2;
+
+    C=W'*W+sigma^2*eye(D); %If I understand this properly, C has the same first k eigenvectors and eigenvalues as S (when the coeff are extracted from the matrix S), and has the same trace (sum of all eigenvalues). If this is true, I expect trace(Cinv*S)= D (unless any of the eigenvalues of C is exactly 0, in which case this is undetermined), and then the only term of the likelihood that changes with k is det(C)
+    aux=bb.^2;
+    if length(aux)<D
+        aux(end+1:D)=0;
+    end
+    detC=prod(aux + sigma^2); %Alt. calculation of det(C) to avoid numerical issues
+
+    logL=-.5*N * (D*log(2*pi) + log(det(C)) + trace(Cinv*S)); 
+    logL=-.5*N * (D*log(2*pi) + log(detC) + trace(pinv(C)*S)); %Alt. calc to avoid numerical errors
+else
+    logL=NaN;
+end
+end
+

--- a/fun/ext/pitools/efficientOverload/effconvn.m
+++ b/fun/ext/pitools/efficientOverload/effconvn.m
@@ -1,0 +1,17 @@
+function [newP] = effconvn(pValues1,pValues2,shape)
+%effconvn Implements the convn function by means of ffts, to -supposedly- be more efficient. It is certainly not the case for small arrays. 
+
+[newP] = effconvnfull(pValues1,pValues2);
+
+if nargin>2
+    warning('Shape argument still not implemented.')
+    if strcmp(shape,'valid')
+        newP=[];
+    elseif strcmp(shape,'same')
+        newP=[];
+    end %Assumes method='full'
+end
+
+
+end
+

--- a/fun/ext/pitools/efficientOverload/effconvnfull.m
+++ b/fun/ext/pitools/efficientOverload/effconvnfull.m
@@ -1,0 +1,9 @@
+function [newP] = effconvnfull(pValues1,pValues2)
+%effconvn Implements the convn function by means of ffts, to -supposedly- be more efficient. It is certainly not the case for small arrays. 
+
+newSize=size(pValues1)+size(pValues2)-1;
+newP=ifftn(fftn(pValues1,newSize).*fftn(pValues2,newSize));
+
+
+end
+

--- a/fun/ext/pitools/math/columnNorm.m
+++ b/fun/ext/pitools/math/columnNorm.m
@@ -1,0 +1,14 @@
+function [w] = columnNorm(X,p,dim)
+%Calculates the p-norm of element in a matrix (along dimension dim)
+%and returns it as a row vector.
+
+if nargin<3
+    dim=1;
+end
+if nargin<2
+    p=2;
+end
+w = sum(abs(X).^p,dim).^(1/p);
+
+end
+

--- a/fun/ext/pitools/math/cosine.m
+++ b/fun/ext/pitools/math/cosine.m
@@ -1,0 +1,13 @@
+function [C] = cosine(X,Y)
+%Calculates the cosine of vectors X,Y, or if they are matrices, the
+%column-wise matrix of cosines
+
+if nargin==1
+    Y=X;
+end
+
+C=(X'*Y)./sqrt(sum(X.^2,1)'*sum(Y.^2,1));
+
+
+end
+

--- a/fun/ext/pitools/math/demean.m
+++ b/fun/ext/pitools/math/demean.m
@@ -1,0 +1,9 @@
+function [Y] = demean(X)
+%Removes the mean of X, acting along columns
+
+aux=mean(X,1);
+Y=X(:,:)-repmat(aux(:,:),[size(X,1),1]);
+Y=reshape(Y,size(X));
+
+end
+

--- a/fun/ext/pitools/plots/saveFig.m
+++ b/fun/ext/pitools/plots/saveFig.m
@@ -1,0 +1,61 @@
+function saveFig(h,dir,fileName,sizeFlag)
+%saveFig saves figure h as .fig and .png for further reference
+set(h,'PaperPositionMode','manual')
+if nargin<4 || isempty(sizeFlag)
+    set(h,'Units','Normalized','OuterPosition',[0 0 1 1])
+end
+if ~exist(dir,'dir')
+    mkdir(dir)
+end
+
+%Save fig:
+if ~exist([dir 'fig/'],'dir')
+    mkdir([dir 'fig/'])
+end
+savefig(h,[dir 'fig/' fileName '.fig'],'compact') ;
+
+%Save eps:
+if ~exist([dir 'eps/'],'dir')
+    mkdir([dir 'eps/'])
+end
+%hgexport(h,[dir 'eps/' fileName '.eps'], hgexport('factorystyle'), 'Format', 'eps');
+%saveas(h,[dir 'eps/' fileName '.eps'], 'epsc');
+
+%print(h,[dir 'eps/' fileName 'vect.eps'],'-depsc','-painters') %Painters is true vectorial
+%Pros of vectorial: light size, no compression needed, can renderize at high resolution at any time.
+%Cons: can't handle transparency, bad handling of 3D objects into 2D image (position quantization artifacts).
+
+print(h,[dir 'eps/' fileName '.eps'],'-depsc','-r600','-opengl') %Opengl forces a bitmap (NOT vector graphics).
+%Pros of rendered eps: can deal with transparency, which vector eps cannot.
+%The image is rendered EXACTLY as it is seen. Vector export does some ugly math that can't guarantee this.
+%Cons: Matlab saves the eps in an ugly way that will cause white lines to appear because of antialiasing preferences in most viewers.
+%The workaround is to import in gimp and export back again (lines go away).
+
+%print(h,[dir 'eps/' fileName '.tif'],'-dtiff','-r600','-opengl') %Compressed tif
+
+%Save png:
+if ~exist([dir 'png/'],'dir')
+    mkdir([dir 'png/'])
+end
+fullName=[dir 'png/' fileName];
+%Workaround for transparent background (on png):
+% save the original background color for later use
+background = get(h, 'color');
+% specify transparent background
+set(h,'color',[0.8 0.8 0.8]);
+% create output file
+set(h,'InvertHardCopy','off');
+%Write it once:
+hgexport(h, [fullName '.png'], hgexport('factorystyle'), 'Format', 'png');
+% write it back out - setting transparency info
+cdata = imread([fullName '.png']);
+imwrite(cdata, [fullName '.png'], 'png', 'BitDepth', 16, 'transparency', [0.8 0.8 0.8])%background)
+set(h,'color',[1 1 1]);
+
+%Save svg
+% if ~exist([dir 'svg/'],'dir')
+%     mkdir([dir 'svg/'])
+% end
+% saveas(h,[dir 'svg/' fileName '.svg'], 'svg');
+
+end

--- a/fun/ext/pitools/signalProcessing/DiscreteTimeFourierTransform.m
+++ b/fun/ext/pitools/signalProcessing/DiscreteTimeFourierTransform.m
@@ -1,0 +1,19 @@
+function [Fdata,fvector] = DiscreteTimeFourierTransform(data,fs)
+%DiscreteTimeFourierTransform Implements the DTFT through the fft. Returns
+%both the spectral content (fft) and the points at which the spectrum is
+%sampled.
+
+Fdata=fft(data);
+N=size(data,1);
+if mod(N,2)==0 %Even case:
+    fvector=fs/N * [-N/2:N/2-1]';
+else %Odd case: we don't get the sample that would correspond to +-fs/2. We can inferr it?
+    fvector=fs/N * [(-N+1)/2:(N-1)/2]';
+end
+
+Fdata=fftshift(Fdata,1);
+%fvector=ifftshift(fvector);
+
+
+end
+

--- a/fun/ext/pitools/signalProcessing/amp_estim.m
+++ b/fun/ext/pitools/signalProcessing/amp_estim.m
@@ -1,0 +1,55 @@
+function [ amplitude,procList ] = amp_estim(signal,fs,mod_ord,cutoff)
+%Estimation of amplitude of a given EMG signal (envelope detection).
+%Following guidelines in Merletti & Parker's book Electromyography (Section
+%6.4, First Edition, p. 139).
+
+N=size(signal,1);
+
+%% Stage 1: whitening
+%[emg2, filter] = whitenEMG(signal,fs);
+%procList{1}=filter; %Whitening filter
+%No whitening:
+emg2=signal;
+procList{1}=[];
+
+%% Stage 2: rectification
+emg3=abs(emg2).^mod_ord;
+procList{2}=['Rectification, order=' num2str(mod_ord)];
+%Alternative: instead of rectification and re-linearization, we could just
+%take the hilbert transform:
+%mod_ord=1;
+%procList{2}='hilbert';
+%emg3=abs(hilbert(egm2));
+
+%% Stage 4: smoothing
+%lowPassFilter=design(fdesign.lowpass('Nb,Na,Fp,Fst',10,5,2*cutoff/fs,2*1.1*cutoff/fs));
+%aux=lowPassFilter.convert('df2');
+%emg4=filtfilt(aux.Numerator,aux.Denominator,emg3);
+%emg4=lowpassfiltering(emg3, cutoff, 5, fs);
+Wn=2*cutoff/fs;
+procList{3}=fdesign.lowpass('Fp,Fst,Ap,Ast',Wn,2*Wn,3,10);
+lowPassFilter=design(procList{3},'butter');
+emg4=filtfilthd_short(lowPassFilter,emg3,'reflect',fs); %1 sec of data for reflective boundaries
+
+%Alternative smoothing: convolving with a moving window (as suggested in
+%Merletti & Parker)
+
+% M=round((72/(8 *fs^2)* median(emg3.^2)/median(diff(diff(emg3)).^2))^.2);
+% if mod(M,2)==0
+%     M=M+1; %making sure it is an odd number
+% end
+% procList{3}= ['Moving Average, rect. window, size=' num2str(M)];
+% window=ones(M,1)/M;
+% %window=hanning(M);
+% fwin=fft(circshift(window,[-round(M/2),0]),N);
+% emg4=zeros(size(signal));
+% for i=1:size(signal,2)
+%     emg4(:,4)=ifft(fft(emg3).*fwin,'symmetric');
+% end
+
+%% Stage 5: relinearization
+amplitude=abs(emg4.^(1/mod_ord)); %This effectively does nothing if mod_ord=1, unless there are negative samples;
+procList{2}=['Relinearization, order=' num2str(mod_ord)];
+
+end
+

--- a/fun/ext/pitools/signalProcessing/circCorr.m
+++ b/fun/ext/pitools/signalProcessing/circCorr.m
@@ -1,0 +1,22 @@
+function lag=circCorr(trace1,trace2)
+%Finds the phase shift of two sinuoidal traces. trace1 and trace2 must be
+%vectors of the same length.
+
+s1=std(trace1);
+s2=std(trace2);
+
+c=[];
+n=length(trace1);
+for t=1:n
+    c(t)=(trace1'*trace2)./((n-1)*s1*s2);
+    trace2=circshift(trace2,1);
+end
+
+[cmax,lag]=max(c);
+lag=lag/n;
+
+if cmax<0.5 || isnan(cmax);
+    lag=NaN;
+end
+
+end

--- a/fun/ext/pitools/signalProcessing/derive.m
+++ b/fun/ext/pitools/signalProcessing/derive.m
@@ -1,0 +1,12 @@
+function [y] = derive(x,fsample)
+derivativeFilter=fsample * 1/8 * [1,2,0,-2,-1]; %Order 5
+derivativeFilter=fsample * 1/32 * [1,4,5,0,-5,-4,-1]; %Order 7
+derivativeFilter=fsample * 1/128 * [1,6,14,14,0,-14,-14,-6,-1]; %Order 9
+order=9;
+%derivativeFilter=fsample * 1/512 * [1,8,.,.,.,0,-14,-14,-6,-1]; %Order 9
+%Get vels:
+y2=conv([x(end:-1:1);x;x(end:-1:1)],derivativeFilter,'same');
+y=y2(length(x)+1:2*length(x));
+
+end
+

--- a/fun/ext/pitools/signalProcessing/estimateDopplerShift.m
+++ b/fun/ext/pitools/signalProcessing/estimateDopplerShift.m
@@ -1,0 +1,89 @@
+function [relativeShift,initTimeDelay] = estimateDopplerShift(signal1,signal2,M)
+%Signals need to have a relative delay <<M on any arbitrarily chosen window of time:
+%this could be fixed by time-aligning previously, assuming that the doppler
+%shift is << M during the time signal length
+%MAximum detectable relative shift is ~ 1/M
+%It is also recommended that signals be high-pass filtered, as it gives
+%better results
+
+if nargin<3
+    k=sqrt(length(signal2))/4; %Approx number of windows that is optimal for the estimation
+    if k>128
+        k=128;
+    end
+    M=ceil(length(signal2)/k);
+end
+
+N=ceil(max([length(signal2) length(signal1)])/M);
+signal1=signal1-mean(signal1);
+signal2=signal2-mean(signal2);
+signal1(end+1:N*M)=0;
+signal2(end+1:N*M)=0; %Padding zeros to have a number of samples that is multiple of the window size (M)
+signal1=signal1-mean(signal1);
+
+E1=sum(signal1.^2);
+E2=sum(signal2.^2);
+
+%% Two step approach: identify outliers, and fit a line. Repeat identifying outliers through the residuals to the line fit, until convergence.
+firstStep=true;
+differences=true;
+while differences
+    
+    clear s x t lineFit
+    t=nan(1,N);
+    for i=1:N
+        aux2=signal2((i-1)*M+1:i*M); %Getting a portion of signal2
+        aux1=signal1((i-1)*M+1:i*M);
+        [~,~,t(i)]=findTimeLag(aux1,aux2);
+%         F1=fft(aux1);
+%         F2=fft(aux2);
+%         F=F1.*conj(F2);
+%         P=ifft(F);
+%         [s(i),t(i)]=max(abs(P));
+%     %     [acor,lag]=xcorr(aux1,aux2,'unbiased');
+%     %     [~,ii]=max(abs(acor));
+%     %     t(i)=lag(ii);
+        x(i)=M/2 + (i-1)*M;
+        
+%         if 5*N*sqrt(sum(aux1.^2)*sum(aux2.^2))<sqrt(E1*E2) %Reject intervals of the signal with too little activity compared to overall
+%             t(i)=NaN;
+%         end
+    end
+    auxI=~isnan(t);
+    properX=x(auxI);
+    properT=t(auxI);
+    if firstStep
+        lineFit=polyfit(properX,properT,1);
+        firstStep=false;
+        iiOld=[];
+    else
+        auxX=x(ii);
+        auxT=t(ii);
+        lineFit=polyfit(auxX(auxI(ii)),auxT(auxI(ii)),1);
+        iiOld=ii;
+    end
+    residuals=abs(t-x*lineFit(1) - lineFit(2));
+    pp=prctile(residuals,[50]);
+    if pp(1)<.5
+        pp(1)=.5; %Because of quantization, we would expect to see at least .5 samples errors even on the best of fits
+    end
+    ii=find(residuals<pp(1) & auxI); %Rejecting outliers
+    
+        if length(ii)>0 && (length(iiOld)~=length(ii) || any(ii~=iiOld))
+            differences=true;
+        else
+            differences=false;
+        end
+
+end
+% figure(1)
+% plot(x,t,'.')
+% hold on
+% plot(x(ii),t(ii),'g.')
+% plot(x,x*lineFit(1)+lineFit(2),'r')
+% hold off
+% legend('Rejected samples','Used samples','Line fit')
+relativeShift=lineFit(1);
+initTimeDelay=lineFit(2); %In samples
+end
+

--- a/fun/ext/pitools/signalProcessing/filtfilthd.m
+++ b/fun/ext/pitools/signalProcessing/filtfilthd.m
@@ -1,0 +1,43 @@
+function [filteredData] = filtfilthd(filterObj,data,method)
+%See also: filtfilthd_short
+warning('Using filtfilthd_short instead of filtfilthd for efficiency purposes. filtfilthd will be deprecated from pitools soon.')
+if nargin<3
+    method='reflect'; %Default
+end
+[filteredData] = filtfilthd_short(filterObj,data,method,[]);
+%Deprecate on May 6th 2018
+
+%Filters data along dim=1 with filterObj first forwards, and then
+%backwards.
+%It is an implementation of filtfilt that works with filter objects from
+%the DSP toolbox.
+%Uses 'reflect' method for dealing with borders.
+
+if size(data,1)==1 
+    warning('filtfiltHD expects input data to be entered as columns, transposing')
+    data=data';
+end
+if size(data,1)<size(data,2)
+    warning('Input data seems to be organized as rows, and filtfilthd filters along columns.')
+end
+
+M=size(data,1);
+
+if nargin<3
+    method='reflect'; %Default
+end
+    switch method
+        case 'reflect'
+            pre=[data(end:-1:1,:)];
+            post=[data(end:-1:1,:)];
+        otherwise         
+            pre=[];
+            post=[];
+    end
+filteredData=filter(filterObj,[pre;data;post]);
+filteredData=filter(filterObj,filteredData(end:-1:1,:));
+filteredData=filteredData(end:-1:1,:);
+filteredData=filteredData([size(pre,1)+1:size(pre,1)+M],:);
+
+end
+

--- a/fun/ext/pitools/signalProcessing/filtfilthd_short.m
+++ b/fun/ext/pitools/signalProcessing/filtfilthd_short.m
@@ -1,0 +1,46 @@
+function [filteredData] = filtfilthd_short(filterObj,data,method,M1)
+%This is a copy of filtfilthd, but limiting the extent of the 'reflect'
+%method for efficiency
+%Filters data along dim=1 with filterObj first forwards, and then
+%backwards.
+%It is an implementation of filtfilt that works with filter objects from
+%the DSP toolbox.
+%By default uses 'reflect' method for dealing with borders.
+
+if size(data,1)==1 
+    warning('filtfiltHD expects input data to be entered as columns, transposing')
+    data=data';
+end
+if size(data,1)<size(data,2)
+    warning('Input data seems to be organized as rows, and filtfilthd filters along columns.')
+end
+
+M=size(data,1);
+
+if nargin<3 || isempty(method)
+    method='reflect'; %Default
+end
+if nargin<4 || isempty(M1)
+    M1=min(1000,size(data,1));
+    warning(['Unspecified size for reflective boundaries, setting to ' num2str(M1) ' samples'])
+else
+    M1=min(round(M1),size(data,1));
+end
+    switch method
+        case 'reflect'
+            post=[data([end:-1:end-M1+1],:)];
+            pre=[data(M1:-1:1,:)];
+        otherwise         
+            pre=[];
+            post=[];
+    end
+filteredData=filter(filterObj,[pre;data;post]);
+filteredData=filter(filterObj,filteredData(end:-1:1,:));
+filteredData=filteredData(end:-1:1,:);
+%filteredData=filtfilt(filterObj,[pre;data;post]); %This should work, and
+%is possibly more efficient, but doesn't.
+filteredData=filteredData([M1+1:M1+M],:);
+
+
+end
+

--- a/fun/ext/pitools/signalProcessing/findTemplate.m
+++ b/fun/ext/pitools/signalProcessing/findTemplate.m
@@ -1,0 +1,121 @@
+function [c,k,a,p] = findTemplate(template,dataseries,whitenFlag)
+%findTemplate implements a simple cross-correlation search to find for
+%occurrences (or near-occurrences) of a given template signal within a
+%longer signal (dataseries).
+%p returns the probability of a match for each sample given by a fitted
+%beta distribution to the data. This value can be used to look for
+%statistically significant matches
+%k returns the scaling of the data to the template. 
+
+N=length(dataseries);
+M=length(template);
+template=detrend(template,'constant');
+
+%Remove NaN
+    dataseries(isnan(dataseries))=0;
+
+%% Compute energy ratios (to be used if matches are found):
+fft1=fft(dataseries);
+fft2=fft(template,N);
+fft3=fft(ones(M,1),N);
+k=ifft(fft1.*conj(fft2))/norm(template)^2;
+
+%% Whitening (improves detection under the assumption of independent samples)
+if nargin>2 && ~isempty(whitenFlag)
+    if whitenFlag==1
+        fftAux=fft1;
+        dataseries=ifft(fftAux./abs(fftAux),'symmetric');
+        %template=ifft(fft(template,N)./abs(fftAux));
+        %template=template(1:M);
+        clear fftAux
+    end
+end
+
+%% Determine auto-correlation matrix of noise
+%The optimal matched filter should take the form: h=pinv(MM)*s
+%where s is the signal we are looking for, and MM the auto-correlation
+%matrix of the noise (undesired signal). If the noise is white, MM=eye(M)
+MM=eye(M); %White noise assumption
+%If we try to empirically determine the auto-correlation matrix (assuming most of the signal is noise):
+%aux=ifft(fft(dataseries).*conj(fft(dataseries))); %Auto-correlation
+%aux=aux(1:M)/aux(1);
+%MM=toeplitz(aux);
+
+%% Define the filter
+filter=pinv(MM)*template;
+filter=filter/norm(filter);
+clear MM
+
+%% Do the filtering
+%Proper and inefficient way:
+% p2=zeros(N-M+1,1);
+% k2=zeros(N-M+1,1);
+% for i=1:N-M+1
+%    subTS=dataseries(i:i+M-1);
+%    subTS=detrend(subTS,'constant');
+%    k=norm(subTS);
+%    subTS=subTS./k;
+%    aux2=subTS'*template/norm(template);
+%    p2(i)=aux2;
+%    k2(i)=k/norm(template);
+% end
+
+%Try an efficient way:
+    fft2=fft(filter,N);
+    fft2(1)=0;
+    fft1=fft(dataseries);
+    p3=ifft(fft1.*conj(fft2),'symmetric'); %Compute the inner product of template with a window of dataseries, all at once! (efficient xcorr)
+    normTerm2=ifft(fft(dataseries.^2).*conj(fft3),'symmetric'); %Not detrended version
+    normTerm2=normTerm2 - 1/M * ifft(fft1.*conj(fft3)).^2; %Here we remove the effect of the moving average (trend)
+    normTerm2(normTerm2<=0)=eps; %Here we force all values to be positive. Non-positive values may happen because of rounding errors.
+    c=p3./(sqrt(normTerm2)*norm(filter));
+    
+    if any(imag(c)~=0) | any(isnan(c))
+        error('findTemplate:complexResults','Computed cosine values were complex.')
+    end
+    if any(abs(c)>1)
+        error('findTemplate:numericalIssues','Computed cosine values were outside the [-1,1] range')
+    end
+
+%% Estimation of a parameter (beta distribution):
+%From data:
+%sigma2=var((1+p3)/2);
+%a=.5*(1/(4*sigma2)-1); %Finding the best-fitting beta distribution given the variance. In theory, if all samples in the signal are iid, a=(M-1)/2;
+H=1/mean(2./(1+c));
+a=(H-1)/(2*H-1); %Another estimation of the distribution parameter that is less susceptible to heavy tails (which may occurr if there are many copies of the template hidden in the data).
+
+%If whitened:
+if nargin>2 && ~isempty(whitenFlag)
+    if whitenFlag==1
+    %In theory, if samples are independent:
+    a=(M-1)/2;
+    end
+end
+
+%% Compute probabilities of observing each value:
+%p=betacdf((1+c)/2,a,a);
+p=[];
+% figure
+% subplot(2,1,1)
+% hist(c)
+% subplot(2,1,2)
+% hist(p)
+%% Make a nice plot to compare histograms.
+% figure
+% [count,x]=hist(p2,100);
+% hold on
+% plot(x,cumsum(count)/(N-M+1))
+% p=betacdf([0:.01:1],a,a);
+% plot(2*[0:.01:1]-1,p,'r')
+% hold off
+
+
+%p=2*abs(betacdf((output+1)/2,(M-1)/300,(M-1)/300)-.5); %This is a way of
+%computing the probability of seen that value from the expected random
+%probability (beta) if we assume that all samples in the dataseries are
+%independent (which is probably not the case, since our signal was
+%filtered, and we are probably over-sampling it greatly).
+
+
+end
+

--- a/fun/ext/pitools/signalProcessing/findTimeLag.m
+++ b/fun/ext/pitools/signalProcessing/findTimeLag.m
@@ -1,0 +1,29 @@
+function [timeDiff,corrCoef,lagInSamples] = findTimeLag(referenceSignal,secondarySignal)
+
+%First: truncate:
+M=max([length(referenceSignal) length(secondarySignal)]);
+referenceSignal(end+1:M)=0;
+secondarySignal(end+1:M)=0;
+
+%Second: correlate
+F1=fft(referenceSignal);
+F2=fft(fftshift(secondarySignal));
+F=F1.*conj(F2);
+P=ifft(F);
+
+%Third: sub-sample:
+aux=0:.01:length(P)-1;
+P2=interp1(0:length(P)-1,P,aux,'spline')/sqrt(sum(referenceSignal.^2)*sum(secondarySignal.^2)); %For sub-sample resolution
+
+%Fourth: find max correlation
+[~,t]=max(abs(P2));
+lagInSamples=aux(t)-floor(M/2); %The -floor(M/2) term accounts for the fftshift
+corrCoef=P2(t);
+
+if abs(corrCoef)<.3
+    warning(['Could not synch signals: r^2= ' num2str(abs(corrCoef))])
+end
+timeDiff = NaN;
+
+end
+

--- a/fun/ext/pitools/signalProcessing/idealHPF.m
+++ b/fun/ext/pitools/signalProcessing/idealHPF.m
@@ -1,0 +1,12 @@
+function [filteredData] = idealHPF(data,fcut)
+%Implements an idealHPF with zero lag
+%fcut is in normalized freq, needs to be in [0,.5]
+
+[Fdata,fvector] = DiscreteTimeFourierTransform(data,1);
+Fdata=Fdata.*repmat((abs(fvector)>fcut),1,size(Fdata,2));
+
+filteredData=ifft(ifftshift(Fdata,1));
+
+
+end
+

--- a/fun/ext/pitools/signalProcessing/idealLPF.m
+++ b/fun/ext/pitools/signalProcessing/idealLPF.m
@@ -1,0 +1,12 @@
+function [filteredData] = idealLPF(data,fcut)
+%Implements an idealLPF with zero lag
+%fcut is in normalized freq, needs to be in [0,.5]
+
+[Fdata,fvector] = DiscreteTimeFourierTransform(data,1);
+Fdata=Fdata.*repmat((abs(fvector)<=fcut),1,size(Fdata,2));
+
+filteredData=ifft(ifftshift(Fdata,1));
+
+
+end
+

--- a/fun/ext/pitools/signalProcessing/interpft1.m
+++ b/fun/ext/pitools/signalProcessing/interpft1.m
@@ -1,0 +1,44 @@
+function [y] = interpft1(x,N,dim)
+%INTERPFT1 Replacement for the original interpft, with mirroring extension to allow for circular
+%continuity
+if nargin<3
+    dim=1;
+end
+
+%% To work for all dimensions
+% %Generate a string to properly ask for extension
+% str=[];
+% M=size(x);
+% for i=1:length(M)
+%     if i~=dim
+%     str=[str,num2str(size(x,i)),','];
+%     else
+%         str=[str,num2str(2*size(x,i)),',']
+%     end
+%     str(end)=';';
+% end
+% 
+% %Initialize extended version
+% eval(['x2=zeros(', str, ');']);
+% 
+% %Fill x2 with copies of x
+% 
+% 
+% %Do the interpolation
+% 
+% %Get the relevant part of the interpolation
+
+%% To work with only dim=1
+
+x=permute(x,[dim 1:dim-1 dim+1:ndims(x)]);
+
+x2=[x;flipud(x)];
+y2=interpft(x2,2*N,1);
+%y=y2(1:N,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:,:);
+y=y2;
+y(N+1:end,:)=[];
+
+y=depermute(y,[dim 1:dim-1 dim+1:ndims(x)]);
+
+end
+

--- a/fun/ext/pitools/signalProcessing/lowpassfiltering.m
+++ b/fun/ext/pitools/signalProcessing/lowpassfiltering.m
@@ -1,0 +1,15 @@
+function data = lowpassfiltering(datafile, cutoff, complexity, samp);
+
+%lowpassfilter function
+%SMM 02/2004
+
+%pass the 'lowpassfilter' function:  1) a data array for filtering,
+                                    %2) the freqency you want removed, and
+                                    %3) the sampling frequency
+%'lowpassfilter' function returns the data array that has been filtered with a
+%lowpass Butterworth filter, with the specified complexity and cutoff frequency
+
+
+
+[b,a]=butter(complexity, (cutoff/(.5*samp)));   %get lowpass filter vectors
+data = filtfilt(b,a,datafile);  %filter using filtfilt funtion to avoid phase shifts

--- a/fun/ext/pitools/signalProcessing/lowpassfiltering2.m
+++ b/fun/ext/pitools/signalProcessing/lowpassfiltering2.m
@@ -1,0 +1,27 @@
+function data1 = lowpassfiltering2(datafile, cutoff, complexity, fs)
+
+%lowpassfilter function, making sure that there is continuity on borders
+%(mirror/circular continuity)
+%PI 07/2013
+
+%pass the 'lowpassfilter' function:  1) a data array for filtering,
+                                    %2) the freqency you want removed, and
+                                    %3) the sampling frequency
+%'lowpassfilter' function returns the data array that has been filtered with a
+%lowpass Butterworth filter, with the specified complexity and cutoff frequency
+
+dataAux=[datafile;datafile(end:-1:1,:)];
+
+[b,a]=butter(complexity, (cutoff/(.5*fs)));   %get lowpass filter vectors
+h = filter(b,a,[1;zeros(size(dataAux,1)-1,1)]);
+
+data2 = fft(dataAux) .* abs(fft(h*ones(1,size(datafile,2)))).^2;
+
+data=ifft(data2);
+data1=data(1:size(datafile,1),:);
+
+
+%Filter characteristics
+% figure
+% plot(abs(fft(h)))
+

--- a/fun/ext/pitools/signalProcessing/matchSignals.m
+++ b/fun/ext/pitools/signalProcessing/matchSignals.m
@@ -1,0 +1,83 @@
+function [alignedSignal2,timeScaleFactor,lagInSamples,gain] = matchSignals(signal1,signal2)
+%alignSignals takes two 1-D time signals and finds a transformation of
+%signal 2 that best matches signal 1. This transformation includes
+%re-sampling (by timeScaleFactor), a delay, and a gain.
+%
+%INPUTS:
+%
+%OUTPUTS:
+%alignedSignal2: a version of signal2 that is aligned (best matches) signal
+%1. It contains NaN for time points where the signal2 was not available. 
+%timeScaleFactor: resampling factor of signal2 to best match signal1. A
+%factor larger than 1 means that the original signal had a lower sampling
+%rate and needed to be interpolated, while a factor lesser than 1 means
+%that the sampling rate was higher (strictly speaking:the signal is always
+%resampled, unless this factor is exactly 1, to a tolerance of 0.5/N, where N
+%is the number of samples of signal 1.
+%Delay: measures the delay in samples of signal2 with respect to signal 1.
+%Because of the resampling, it is interpretation might be a little funky,
+%but esentially it measures how many samples later the initial timepoint
+%of signal1 happens in signal2, assuming that the sampling rate of signal1
+%is the correct one. A positive number means that signal2 started recording
+%EARLIER than signal1, and a negative number means the opposite.
+%Gain: a scaling factor so that signal2 matches signal1 the best possible,
+%after the resampling and time-shifting.
+
+%% Step 1: determine mis-match in sampling rates & time delay
+
+%Find lag, align & make signals equal length:
+[~,~,lagInSamples] = findTimeLag(signal1,signal2);
+newSignal2 = resampleShiftAndScale(signal2,1,lagInSamples,1);
+if length(newSignal2)>length(signal1)
+    newSignal2(length(signal1)+1:end)=[];
+else
+    signal1(length(newSignal2)+1:end)=[];
+end
+
+%Find doppler shift: (sampling rate mis-match)
+[relativeShift,~] = estimateDopplerShift(signal1,newSignal2);
+timeScaleFactor=1-relativeShift;
+newSignal2 = resampleShiftAndScale(newSignal2,timeScaleFactor,0,1);
+
+%Find new lag, align & make signals equal length:
+[~,~,lagInSamples2] = findTimeLag(signal1,newSignal2);
+newSignal2 = resampleShiftAndScale(newSignal2,1,lagInSamples2,1);
+if length(newSignal2)>length(signal1)
+    newSignal2(length(signal1)+1:end)=[];
+else
+    signal1(length(newSignal2)+1:end)=[];
+end
+lagInSamples=lagInSamples+lagInSamples2;
+
+%% Step 2:  determine best-gain
+gain=newSignal2'/signal1';
+alignedSignal2=newSignal2/gain;
+
+
+%% Step 3: Check/debug
+
+%Re-estimate parameters and hope they are 0
+[relativeShift,~] = estimateDopplerShift(signal1,alignedSignal2);
+[~,~,initTimeDelay] = findTimeLag(signal1,alignedSignal2);
+if abs(relativeShift)>2/length(signal2)
+    warning('Signal resampling did not seem to work properly')
+end
+if abs(initTimeDelay)>1
+    warning('Time shifting did not seem to work properly')
+end
+
+% gain=newSignal2'/signal1';
+% 
+% figure
+% hold on
+% plot(signal1)
+% plot(alignedSignal2,'r')
+% hold off
+% 
+% E=sum((signal1-alignedSignal2).^2);
+% figure
+% plot(signal1-alignedSignal2)
+% 
+
+end
+

--- a/fun/ext/pitools/signalProcessing/polyfit1PCA.m
+++ b/fun/ext/pitools/signalProcessing/polyfit1PCA.m
@@ -1,0 +1,20 @@
+function [pp] = polyfit1PCA(x,y,varNormalizeFlag)
+%Finding best-fit line through PCA
+my=mean(y);
+y=y(:)'-my;
+mx=mean(x);
+x=x(:)'-mx;
+if nargin>2 && ~isempty(varNormalizeFlag) && varNormalizeFlag==1
+  vx=std(x);
+  vy=std(y);
+else
+  vx=1;
+  vy=1;
+end
+[ppp,ccc,aaa]=pca([x/vx; y/vy],'Centered',false);
+ccc=ccc(:,1);
+pp(1)=ccc(2)*vy/(ccc(1)*vx);
+pp(2)=my-mx*pp(1);
+
+
+end

--- a/fun/ext/pitools/signalProcessing/resampleShiftAndScale.m
+++ b/fun/ext/pitools/signalProcessing/resampleShiftAndScale.m
@@ -1,0 +1,41 @@
+function newSignals = resampleShiftAndScale(signals,timeScaleFactor,lagInSamples,scaleGain)
+%Function that does the same thing as matchSignals, but when the
+%parameters are given/known
+
+
+[M,N]=size(signals);
+
+%% Resample: (not using 'resample' function because i'm interested in very
+%small resampling rates, on the order of 1+-1e-6
+if abs(timeScaleFactor-1)>.5/M %Only resampling if there is at least a half a sample shift during the full timecourse
+    for i=1:N
+        newSignals(:,i)=interp1(1:M,signals(:,i),timeScaleFactor*[1:floor(M/timeScaleFactor)],'linear')';
+        newSignals(1,i)=signals(1,i); %For same reason interp1 returns NaN when evaluating at same position
+    end
+else
+    newSignals=signals;
+end
+
+%% Time-shift
+aux=round(lagInSamples); 
+d=lagInSamples-aux;
+%First shift an integer number of samples:
+if lagInSamples<0
+    newSignals=newSignals(abs(aux)+1:end,:); %Throw first samples
+else
+    newSignals=[zeros(abs(aux),N); newSignals]; %Pad zeros to add samples
+end
+
+%Then, correct for sub-sample interpolation.
+% k=1000;
+% F=fft([newSignals;zeros(k,size(newSignals,2))]);
+% Fd=exp(1i*2*pi*[0:size(F,1)-1]/size(F,1)).^d;
+% newSignals=ifft(bsxfun(@times,F,Fd'),'symmetric');
+% newSignals=newSignals(1:end-k,:);
+
+
+%% Scale:
+newSignals=newSignals/scaleGain;
+
+end
+

--- a/fun/ext/pitools/signalProcessing/truncateToSameLength.m
+++ b/fun/ext/pitools/signalProcessing/truncateToSameLength.m
@@ -1,0 +1,14 @@
+function [newMatrix1, newMatrix2] = truncateToSameLength(matrix1,matrix2)
+%Works along dim 1, by truncating the longest of matrix1 and 2 so that
+%size(newMatrix1,1)=size(newMatrix2,1)
+
+if size(matrix2,1)>size(matrix1,1)
+    newMatrix2=matrix2(1:size(matrix1,1),:);
+    newMatrix1=matrix1;
+else
+    newMatrix1=matrix1(1:size(matrix2,1),:);
+    newMatrix2=matrix2;
+end
+
+end
+

--- a/fun/ext/pitools/statTest/BenjaminiHochberg.m
+++ b/fun/ext/pitools/statTest/BenjaminiHochberg.m
@@ -1,0 +1,73 @@
+function [h,pThreshold,i1,pAdjusted] = BenjaminiHochberg(p,fdr,twoStageFlag)
+%Performs the Benjamini-Hochberg procedure to determine significance in
+%multiple comparisons while controlling the False Discovery Rate (number of
+%false positives as a % of the number of total comparisons). This is a
+%less taxing alternative to performing a Bonferroni correction, for example.
+%FDR control is done in expectation over many realizations.
+%See also: mafdr
+
+%INPUT:
+%p: vector of p-values from the multiple comparisons, has to be 1-D
+%fdr: value in [0,1] that determines the (expected) False Discovery Rate that is
+%tolerated
+%twoStageFlag: if true, it performs the two-stage procedure suggested in
+%Benjamini, Krieger and Yekuteli 2006, which maintains fdr control
+%guarantees (under independent tests) but has more power. Default = false.
+%OUTPUT:
+%h= binary vector that is 1 if the corresponding p-value was deemed
+%significant, and 0 if not.
+%pThreshold = value that ends up being the cut-off for p. Should satisfy:
+%h = p<=pThreshold = pAdjusted<fdr
+%i1 = no. of significant results, equals sum(h)
+%pAdjusted = adjusted p-values
+
+%Validated on Oct 19th 2017 against fdr_bh() function from Matlab Exchange,
+%and on Nov 29th 2018 agains BioInformatic's Toolbox mafdr()
+%References:
+%Benjamini & Hochberg 1995
+%Yekuteli & Benjamini 1999 (for definition of adjusted p-values)
+%Benjamini, Krieger and Yekuteli 2006 (for two-stage procedure)
+
+if nargin<3 || isempty(twoStageFlag)
+    twoStageFlag=false;
+end
+if twoStageFlag
+    fdr=fdr/(1+fdr); %BKY procedure requires using this value
+    %in the first and second pass for FDR guarantee, although authors later use fdr
+    %itself for the first pass and claim that it is ok in practice.
+end
+
+M=numel(p); %No. of total comparisons
+
+[p1,idx]=sort(p(:),'ascend');
+h1=zeros(size(p1));
+ii=find(p1 < fdr*[1:M]'/M,1,'last');
+if isempty(ii)
+    i1=0;
+else
+    i1=ii;
+end
+
+h1(1:i1)=1; %Significant results
+h=nan(size(p));
+h(idx)=h1; %Re-sorting
+
+pThreshold=p1(ii);
+
+if nargout>3 %Computing adjusted p-values
+    %Adjusted p-values are the thing that is compared to fdr
+    pAdjusted=nan(size(p));
+    newP=p1*M./[1:M]';
+    for i=(length(newP)-1):-1:1
+        if newP(i)>newP(i+1)
+            newP(i)=newP(i+1);
+        end
+    end
+    pAdjusted(idx)=newP;
+end
+
+if twoStageFlag
+    [h,pThreshold,i1] = BenjaminiHochberg(p,fdr*M/(M-i1),false);
+end
+
+end

--- a/fun/ext/pitools/usefulCode/cellisa.m
+++ b/fun/ext/pitools/usefulCode/cellisa.m
@@ -1,0 +1,8 @@
+function b = cellisa(cell,type)
+b=[];
+for i=1:length(cell)
+    b(i)=isa(cell{i},type);
+end
+
+end
+

--- a/fun/ext/pitools/usefulCode/checkBelongings.m
+++ b/fun/ext/pitools/usefulCode/checkBelongings.m
@@ -1,0 +1,38 @@
+function [flag] = checkBelongings(idx1,idx2)
+%checkBelongings Gets two vectors of equal size and checks that no pair of
+%indexes are repeated, i.e. that there is no i and j such that
+%idx1(i)==idx1(j) && idx2(i)==idx2(j)
+%The idea is that the idx vectors represents belongings to groups/clusters
+%of a list of elements, and we want to make sure that no two elements have equal
+%belongings in the two groups (Pauli's exclusion principle)
+%Returns true if the exclusion criteria is fulfilled, false otherwise
+
+%Check inputs are vectors are of same size
+if length(idx1)~=numel(idx1) || length(idx2)~=numel(idx2)
+    disp('Error in checkBelongings: inputs are not vectors')
+    flag=[];
+    return
+end
+if length(idx1)~=length(idx2)
+    disp('Error in checkBelongings: vectors are not of the same size')
+    flag=[];
+    return
+end
+
+
+
+%Check belongings:
+Nelem=length(idx1);
+%M=sparse([],[],[],max(idx1),max(idx2),Nelem^2); %Create belonging matrix (sparse to avoid memory problems)
+%for i=1:length(idx1)
+%   M(idx1(i),idx2(i)) = M(idx1(i),idx2(i))+1;
+%end
+M=crosstab(idx1,idx2);
+
+if any(M(:)>1)
+    flag=false;
+else
+    flag=true;
+end
+end
+

--- a/fun/ext/pitools/usefulCode/compareLists.m
+++ b/fun/ext/pitools/usefulCode/compareLists.m
@@ -1,0 +1,15 @@
+function [bool,idxs] = compareLists(list1,list2)
+%Searches for strings in list2 to match any string in list1.
+%List2 has to be a cell array of strings.
+%List 1 has to be a cell array containing strings or cell arrays of
+%strings, to allow for multiple alternative spellings.
+%bool & idxs are of the same size as list2
+%bool(i) is true if list2{i} is found in list1
+%idxs(i), if bool(i)==true, contains the element of list1 that contains the string list2{i} such that
+%any(strcmp(list2{i},list1{idxs(i)}))=true. Note that since list1{idxs(i)}
+%may contain a cell array of strings, strcmp(list2{i},list1{idxs(i)}) may
+%return a boolean vector
+warning('Deprecated: use compareListsNested')
+[bool,idxs] = compareListsNested(list1,list2);
+end
+

--- a/fun/ext/pitools/usefulCode/compareListsNested.m
+++ b/fun/ext/pitools/usefulCode/compareListsNested.m
@@ -1,0 +1,44 @@
+function [bool,idxs] = compareListsNested(list1,list2)
+%Searches for strings in list2 to match any string in list1.
+%List2 has to be a cell array of strings.
+%List 1 has to be a cell array containing strings or cell arrays of
+%strings, to allow for multiple alternative spellings.
+%bool & idxs are of the same size as list2
+%bool(i) is true if list2{i} is found in list1
+%idxs(i), if bool(i)==true, contains the element of list1 that contains the string list2{i} such that
+%any(strcmp(list2{i},list1{idxs(i)}))=true. Note that since list1{idxs(i)}
+%may contain a cell array of strings, strcmp(list2{i},list1{idxs(i)}) may
+%return a boolean vector
+%If there are many matches, idxs will point to the LAST match found
+
+if isa(list2,'char')
+    list2={list2};
+end
+if ~isa(list2,'cell') || ~all(cellfun(@(x) isa(x,'char'),list2))
+    error('List2 has to be a cell array containing strings.');
+end
+if all(cellfun(@(x) isa(x,'char'),list1)) %Shortcut for when list1 and list2 are both cells of strings:
+    [bool,idxs] = compareListsFast(list1,list2);
+else
+%TO DO: make this more efficient by running as the first part (above this line) for all the
+%chars in list1, and only doing the second part (from this line on) for the non-chars in list1
+%[currently we do the first part only if they are ALL chars, and if not we
+%go ahead element by element, which is inefficient]
+idxs=nan(size(list2));
+    bool=false(size(list2));
+    for i=1:length(list1)
+        if isa(list1{i},'cell')
+            [aux,~] = compareListsNested(list1{i},list2);
+        elseif isa(list1{i},'char')
+            aux=strcmp(list1{i},list2); %Compares the full list2 to one element of list1
+        else
+            error('List1 has to be a cell array containing strings or nested cell-arrays of strings');
+        end
+        idxs(aux)=i;
+        bool=bool | aux;
+    end
+end
+
+
+end
+

--- a/fun/ext/pitools/usefulCode/depermute.m
+++ b/fun/ext/pitools/usefulCode/depermute.m
@@ -1,0 +1,10 @@
+function [B] = depermute(A,order)
+%DEPERMUTE is the inverse function of permute, given the order parameter,
+%so that if A=permute(C,order) [Matlab embedded function], and B=depermute(A,order), then B=C.
+
+newOrder(order)=order;
+B=permute(A,newOrder);
+
+
+end
+

--- a/fun/ext/pitools/usefulCode/diverging_map.m
+++ b/fun/ext/pitools/usefulCode/diverging_map.m
@@ -1,0 +1,253 @@
+function[map] = diverging_map(s,rgb1,rgb2)
+%This function is based on Kenneth Moreland's code for greating Diverging
+%Colormaps.  Created by Andy Stein.
+%
+%s is a vector that goes between zero and one 
+
+map = zeros(length(s),3);
+for i=1:length(s)
+    map(i,:) = diverging_map_1val(s(i),rgb1,rgb2);
+end
+end
+
+% Interpolate a diverging color map.
+    function[result] = diverging_map_1val(s, rgb1, rgb2)
+    %s1 is a number between 0 and 1
+
+        lab1 = RGBToLab(rgb1);
+        lab2 = RGBToLab(rgb2);
+  
+        msh1 = LabToMsh(lab1);
+        msh2 = LabToMsh(lab2);
+
+        % If the endpoints are distinct saturated colors, then place white in between
+        % them.
+        if msh1(2) > 0.05 && msh2(2) > 0.05 && AngleDiff(msh1(3),msh2(3)) > 0.33*pi    
+            % Insert the white midpoint by setting one end to white and adjusting the
+            % scalar value.
+            Mmid = max(msh1(1), msh2(1));
+            Mmid = max(88.0, Mmid);
+            if (s < 0.5)
+                msh2(1) = Mmid;  msh2(2) = 0.0;  msh2(3) = 0.0;
+                s = 2.0*s;
+            else
+                msh1(1) = Mmid;  msh1(2) = 0.0;  msh1(3) = 0.0;
+                s = 2.0*s - 1.0;
+            end
+        end
+
+        % If one color has no saturation, then its hue value is invalid.  In this
+        % case, we want to set it to something logical so that the interpolation of
+        % hue makes sense.
+        if ((msh1(2) < 0.05) && (msh2(2) > 0.05))
+            msh1(3) = AdjustHue(msh2, msh1(1));
+        elseif ((msh2(2) < 0.05) && (msh1(2) > 0.05))
+            msh2(3) = AdjustHue(msh1, msh2(1));
+        end
+
+        mshTmp(1) = (1-s)*msh1(1) + s*msh2(1);
+        mshTmp(2) = (1-s)*msh1(2) + s*msh2(2);
+        mshTmp(3) = (1-s)*msh1(3) + s*msh2(3);
+
+        % Now convert back to RGB
+        labTmp = MshToLab(mshTmp);
+        result = LabToRGB(labTmp);
+        1;
+    end
+
+
+%Convert to and from a special polar version of CIELAB (useful for creating
+%continuous diverging color maps).
+    function[Msh] = LabToMsh(Lab)  
+        L = Lab(1);
+        a = Lab(2);
+        b = Lab(3);
+
+        M = sqrt(L*L + a*a + b*b);
+        s = (M > 0.001) * acos(L/M);
+        h = (s > 0.001) * atan2(b,a);
+
+        Msh = [M s h];
+    end
+
+    function[Lab] = MshToLab(Msh)
+        M = Msh(1);
+        s = Msh(2);
+        h = Msh(3);
+
+        L = M*cos(s);
+        a = M*sin(s)*cos(h);
+        b = M*sin(s)*sin(h);
+
+        Lab = [L a b];
+    end
+
+%Given two angular orientations, returns the smallest angle between the two.
+    function[adiff] = AngleDiff(a1, a2)
+        v1    = [cos(a1) sin(a1)];
+        v2    = [cos(a2) sin(a2)];        
+        adiff = acos(dot(v1,v2));
+    end
+        
+%% For the case when interpolating from a saturated color to an unsaturated
+%% color, find a hue for the unsaturated color that makes sense.
+    function[h] = AdjustHue(msh, unsatM)
+
+        if msh(1) >= unsatM-0.1                    
+            %%The best we can do is hold hue constant.
+            h = msh(3);
+        else
+            % This equation is designed to make the perceptual change of the
+            % interpolation to be close to constant.
+            hueSpin = (msh(2)*sqrt(unsatM^2 - msh(1)^2)/(msh(1)*sin(msh(2))));
+    
+            % Spin hue away from 0 except in purple hues.
+            if (msh(3) > -0.3*pi)
+                h = msh(3) + hueSpin;
+            else
+                h = msh(3) - hueSpin;
+            end
+        end
+    end
+
+    function [xyz] = LabToXYZ(Lab)
+        %LAB to XYZ
+        L = Lab(1); a = Lab(2); b = Lab(3);
+
+        var_Y = ( L + 16 ) / 116;
+        var_X = a / 500 + var_Y;
+        var_Z = var_Y - b / 200;
+
+        if ( var_Y^3 > 0.008856 ) 
+          var_Y = var_Y^3;
+        else
+          var_Y = ( var_Y - 16.0 / 116.0 ) / 7.787;
+        end
+        if ( var_X^3 > 0.008856 ) 
+          var_X = var_X^3;
+        else
+          var_X = ( var_X - 16.0 / 116.0 ) / 7.787;
+        end
+        if ( var_Z^3) > 0.008856 
+          var_Z = var_Z^3;
+        else
+          var_Z = ( var_Z - 16.0 / 116.0 ) / 7.787;
+        end
+
+        ref_X = 0.9505;
+        ref_Y = 1.000;
+        ref_Z = 1.089;
+
+
+        x = ref_X * var_X;     %ref_X = 0.9505  Observer= 2 deg Illuminant= D65
+        y = ref_Y * var_Y;     %ref_Y = 1.000
+        z = ref_Z * var_Z;     %ref_Z = 1.089
+
+        xyz = [x y z];
+    end
+
+    function[Lab] = XYZToLab(xyz)
+        x = xyz(1); y = xyz(2); z = xyz(3);
+
+        ref_X = 0.9505;
+        ref_Y = 1.000;
+        ref_Z = 1.089;
+        var_X = x / ref_X;  %ref_X = 0.9505  Observer= 2 deg, Illuminant= D65
+        var_Y = y / ref_Y;  %ref_Y = 1.000
+        var_Z = z / ref_Z;  %ref_Z = 1.089
+
+        if ( var_X > 0.008856 ), var_X = var_X^(1/3);
+        else                     var_X = ( 7.787 * var_X ) + ( 16.0 / 116.0 ); end
+        if ( var_Y > 0.008856 ), var_Y = var_Y^(1/3);
+        else                     var_Y = ( 7.787 * var_Y ) + ( 16.0 / 116.0 ); end
+        if ( var_Z > 0.008856 ), var_Z = var_Z^(1/3);
+        else                     var_Z = ( 7.787 * var_Z ) + ( 16.0 / 116.0 ); end
+
+        L = ( 116 * var_Y ) - 16;
+        a = 500 * ( var_X - var_Y );
+        b = 200 * ( var_Y - var_Z );
+
+        Lab = [L a b];
+    end
+
+function[rgb] = XYZToRGB(xyz)
+  
+  %ref_X = 0.9505;        %Observer = 2 deg Illuminant = D65
+  %ref_Y = 1.000;
+  %ref_Z = 1.089;
+  
+  x = xyz(1); y = xyz(2); z = xyz(3);
+  r = x *  3.2406 + y * -1.5372 + z * -0.4986;
+  g = x * -0.9689 + y *  1.8758 + z *  0.0415;
+  b = x *  0.0557 + y * -0.2040 + z *  1.0570;
+
+  % The following performs a "gamma correction" specified by the sRGB color
+  % space.  sRGB is defined by a canonical definition of a display monitor and
+  % has been standardized by the International Electrotechnical Commission (IEC
+  % 61966-2-1).  The nonlinearity of the correction is designed to make the
+  % colors more perceptually uniform.  This color space has been adopted by
+  % several applications including Adobe Photoshop and Microsoft Windows color
+  % management.  OpenGL is agnostic on its RGB color space, but it is reasonable
+  % to assume it is close to this one.
+  if (r > 0.0031308), r = 1.055 * r^( 1 / 2.4 ) - 0.055;
+  else r = 12.92 * (r); end
+  if (g > 0.0031308), g = 1.055 * g^( 1 / 2.4 ) - 0.055;
+  else  g = 12.92 * (g); end
+  if (b > 0.0031308), b = 1.055 * b^( 1 / 2.4 ) - 0.055;
+  else b = 12.92 * (b); end
+
+  % Clip colors. ideally we would do something that is perceptually closest
+  % (since we can see colors outside of the display gamut), but this seems to
+  % work well enough.
+  maxVal = r;
+  if (maxVal < g), maxVal = g; end
+  if (maxVal < b), maxVal = b; end
+  if (maxVal > 1.0)    
+    r = r/maxVal;
+    g = g/maxVal;
+    b = b/maxVal;
+  end
+  if (r<0), r=0; end
+  if (g<0), g=0; end
+  if (b<0), b=0; end
+  
+  rgb = [r g b];
+end
+
+%-----------------------------------------------------------------------------
+function[xyz] = RGBToXYZ(rgb)
+
+  r = rgb(1); g = rgb(2); b = rgb(3);
+
+  % The following performs a "gamma correction" specified by the sRGB color
+  % space.  sRGB is defined by a canonical definition of a display monitor and
+  % has been standardized by the International Electrotechnical Commission (IEC
+  % 61966-2-1).  The nonlinearity of the correction is designed to make the
+  % colors more perceptually uniform.  This color space has been adopted by
+  % several applications including Adobe Photoshop and Microsoft Windows color
+  % management.  OpenGL is agnostic on its RGB color space, but it is reasonable
+  % to assume it is close to this one.
+  if ( r > 0.04045 ), r = (( r + 0.055 ) / 1.055)^2.4;
+  else                r = r / 12.92; end
+  if ( g > 0.04045 ), g = (( g + 0.055 ) / 1.055)^2.4;
+  else                g = g / 12.92; end
+  if ( b > 0.04045 ), b = (( b + 0.055 ) / 1.055)^2.4;
+  else                b = b / 12.92; end
+
+  %Observer. = 2 deg, Illuminant = D65
+  x = r * 0.4124 + g * 0.3576 + b * 0.1805;
+  y = r * 0.2126 + g * 0.7152 + b * 0.0722;
+  z = r * 0.0193 + g * 0.1192 + b * 0.9505;
+  
+  xyz = [x y z];
+end
+
+function[rgb] = LabToRGB(Lab)
+  xyz = LabToXYZ(Lab);
+  rgb = XYZToRGB(xyz);
+end
+
+function[Lab] = RGBToLab(rgb)
+  xyz = RGBToXYZ(rgb);
+  Lab = XYZToLab(xyz);
+end

--- a/fun/ext/pitools/usefulCode/sliceArray.m
+++ b/fun/ext/pitools/usefulCode/sliceArray.m
@@ -1,0 +1,20 @@
+function [slices] = sliceArray(data,inds,dim)
+%sliceArray returns a subset of 'slices' of an array (indexed by inds)
+%along dimension dim. %Preferable to solutions using permute() which create copies of the array,
+%which is not desirable for large arrays.
+%It is equivalent to slices=data(:,:,..,:,inds,:,...,:), where 'inds' is
+%located at the 'dim' dimension of the array.
+
+nd=ndims(data);
+if dim>nd
+    error('')
+end
+N=size(data,dim);
+if any(inds>N | inds<1)
+    error()
+end
+prefix=repmat(':,',1,dim-1);
+suffix=repmat(',:',1,nd-dim);
+eval(['slices=data(' prefix 'inds' suffix ');'])
+end
+

--- a/fun/ext/pitools/usefulCode/xticklabel_rotate90_cell.m
+++ b/fun/ext/pitools/usefulCode/xticklabel_rotate90_cell.m
@@ -1,0 +1,71 @@
+function xticklabel_rotate90(XTick,xTickLabels,varargin)
+%XTICKLABEL_ROTATE90 - Rotate numeric Xtick labels by 90 degrees
+%
+% Syntax: xticklabel_rotate90(XTick)
+%
+% Input:  XTick - vector array of XTick positions & values (numeric)
+%
+% Output:  none
+%
+% Example 1:  Set the positions of the XTicks and rotate them
+%    figure;  plot([1960:2004],randn(45,1)); xlim([1960 2004]);
+%    xticklabel_rotate90([1960:2:2004]);
+%    %If you wish, you may set a few text "Property-value" pairs
+%    xticklabel_rotate90([1960:2:2004],'Color','m','Fontweight','bold');
+%
+% Example 2:  %Rotate XTickLabels at their current position
+%    XTick = get(gca,'XTick');
+%    xticklabel_rotate90(XTick);
+%
+% Other m-files required: none
+% Subfunctions: none
+% MAT-files required: none
+%
+% See also: TEXT,  SET
+
+% Author: Denis Gilbert, Ph.D., physical oceanography
+% Maurice Lamontagne Institute, Dept. of Fisheries and Oceans Canada
+% email: gilbertd@dfo-mpo.gc.ca  Web: http://www.qc.dfo-mpo.gc.ca/iml/
+% February 1998; Last revision: 24-Mar-2003
+
+if ~isnumeric(XTick)
+   error('XTICKLABEL_ROTATE90 requires a numeric input argument');
+end
+
+%Make sure XTick is a column vector
+XTick = XTick(:);
+
+%Set the Xtick locations and set XTicklabel to an empty string
+set(gca,'XTick',XTick,'XTickLabel','')
+
+% Define the xtickLabels
+%xTickLabels = num2str(XTick);
+
+% Determine the location of the labels based on the position
+% of the xlabel
+hxLabel = get(gca,'XLabel');  % Handle to xlabel
+xLabelString = get(hxLabel,'String');
+
+if ~isempty(xLabelString)
+   warning('You may need to manually reset the XLABEL vertical position')
+end
+
+set(hxLabel,'Units','data');
+xLabelPosition = get(hxLabel,'Position');
+y = xLabelPosition(2);
+y=1.1;
+
+%CODE below was modified following suggestions from Urs Schwarz
+%y=repmat(y,size(XTick,1),1);
+% retrieve current axis' fontsize
+fs = get(gca,'fontsize');
+
+for i=1:length(XTick)
+% Place the new xTickLabels by creating TEXT objects
+hText = text(XTick(i), y, xTickLabels{i},'fontsize',fs);
+
+% Rotate the text objects by 90 degrees
+set(hText,'Rotation',90,'HorizontalAlignment','right',varargin{:})
+end
+
+%------------- END OF CODE --------------


### PR DESCRIPTION
This pull request entirely removes the 'pi-tools' and 'markerDataCleaning' submodule repositories and nativizes only the functions used or referenced within the 'labTools' repository. This simplifies the setup of 'labTools' by no longer requiring initialization or updating of the submodules. It also considerably simplifies the 'labTools' repository since only ~25 functions from both repositories are referenced and the repositories contain many more functions. This also facilitates maintenance and updating of these functions since the original repositories do not seem to be maintained any longer and the code contains out-of-date MATLAB. This update has been tested by running the 'c3d2mat' pipeline and verifying that all three output MAT data files are identical in size as before these two commits (using two trials, Adaptation 1, OG Post 1, from a C3 session). The 'compareAdaptationData' function was also used to show that the 'adaptationData' objects are identical before and after these commits. This reduces bloat in the 'labTools' repository and sets us up for future improvements to the code, including signal synchronization. The commit ID has been preserved in the 'ATTRIBUTION' files so that it is clear to track where this code has diverged. NWB